### PR TITLE
Add is_running method to DashboardServer

### DIFF
--- a/python/src/gigavector/dashboard/server.py
+++ b/python/src/gigavector/dashboard/server.py
@@ -1591,7 +1591,7 @@ class DashboardServer:
             self._thread = None
     def is_running(self) -> bool:
         """Check if dashboard is running in the background"""
-        return self._httpd is not None and self._thread is not None
+        return self._httpd is not None and self._thread is not None and self._thread.is_alive()
 
     @property
     def port(self) -> int:

--- a/python/src/gigavector/dashboard/server.py
+++ b/python/src/gigavector/dashboard/server.py
@@ -1589,6 +1589,9 @@ class DashboardServer:
         if self._thread is not None:
             self._thread.join(timeout=5)
             self._thread = None
+    def is_running(self) -> bool:
+        """Check if dashboard is running in the background"""
+        return self._httpd is not None and self._thread is not None
 
     @property
     def port(self) -> int:

--- a/python/src/gigavector/dashboard/server.py
+++ b/python/src/gigavector/dashboard/server.py
@@ -1573,8 +1573,15 @@ class DashboardServer:
 
     def start(self) -> None:
         """Start the dashboard server in a background daemon thread."""
-        if self._httpd is not None:
+        if self._thread is not None and self._thread.is_alive():
             raise RuntimeError("Server is already running")
+
+        if self._httpd is not None:
+            self._httpd.server_close()
+            self._httpd = None
+
+        self._thread = None
+
         self._httpd = _DashboardHTTPServer(self._db, (self._host, self._port))
         self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
         self._thread.start()
@@ -1589,9 +1596,10 @@ class DashboardServer:
         if self._thread is not None:
             self._thread.join(timeout=5)
             self._thread = None
+
     def is_running(self) -> bool:
-        """Check if dashboard is running in the background"""
-        return self._httpd is not None and self._thread is not None and self._thread.is_alive()
+        """Return whether the dashboard server thread is currently alive."""
+        return self._thread is not None and self._thread.is_alive()
 
     @property
     def port(self) -> int:

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 from gigavector import (
     Database,
@@ -9,9 +10,46 @@ from gigavector import (
     ReplicationManager,
     ReplicationConfig,
 )
+from gigavector.dashboard.server import DashboardServer
 
 
 class TestAPI(unittest.TestCase):
+    def test_dashboard_server_recovers_from_stale_thread_state(self):
+        server = DashboardServer(object(), port=0)
+        stale_thread = mock.Mock()
+        stale_thread.is_alive.return_value = False
+        stale_httpd = mock.Mock()
+        new_httpd = mock.Mock()
+        new_thread = mock.Mock()
+
+        server._httpd = stale_httpd
+        server._thread = stale_thread
+
+        self.assertFalse(server.is_running())
+
+        with mock.patch(
+            "gigavector.dashboard.server._DashboardHTTPServer", return_value=new_httpd
+        ) as httpd_cls, mock.patch(
+            "gigavector.dashboard.server.threading.Thread", return_value=new_thread
+        ) as thread_cls:
+            server.start()
+
+        stale_httpd.server_close.assert_called_once_with()
+        httpd_cls.assert_called_once_with(server._db, (server._host, server._port))
+        thread_cls.assert_called_once_with(target=new_httpd.serve_forever, daemon=True)
+        new_thread.start.assert_called_once_with()
+        self.assertIs(server._httpd, new_httpd)
+        self.assertIs(server._thread, new_thread)
+
+    def test_dashboard_server_start_raises_when_thread_alive(self):
+        server = DashboardServer(object(), port=0)
+        server._httpd = mock.Mock()
+        server._thread = mock.Mock()
+        server._thread.is_alive.return_value = True
+
+        with self.assertRaisesRegex(RuntimeError, "Server is already running"):
+            server.start()
+
     def test_basic_add_search(self):
         import tempfile
         import os


### PR DESCRIPTION
Dashboard server class was lacking any methods to verify if the server is running or not.
Added is_running as a simple wrapper to check if background thread is working or not.