### PR TITLE
Fix Windows build: MSVC support and correct cmake path in sdist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,12 @@ elseif(MSVC)
     # Keep warnings high on MSVC, but do not inject GCC/Clang flags.
     add_compile_options(/W4)
 endif()
-set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
-set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
+# MSVC already has sensible per-config defaults (/O2 /Od /Zi); only set
+# GCC/Clang style flags for those compilers.
+if(NOT MSVC)
+    set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
+    set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
+endif()
 
 # Ensure objects do not request an executable stack on ELF targets only.
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang" AND NOT WIN32 AND NOT APPLE)
@@ -40,6 +44,12 @@ endif()
 
 # Position Independent Code for shared libraries
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Export all symbols from the DLL on MSVC (mirrors MinGW --export-all-symbols
+# default so callers don't need per-symbol __declspec(dllexport) annotations).
+if(WIN32 AND BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 
 # Source files
 file(GLOB_RECURSE GV_SOURCE_FILES CONFIGURE_DEPENDS 
@@ -176,7 +186,11 @@ if(BUILD_TESTS)
         get_filename_component(TEST_NAME ${TEST_SRC} NAME_WE)
         string(REPLACE "test_" "" TEST_NAME ${TEST_NAME})
         add_executable(test_${TEST_NAME} ${TEST_SRC})
-        target_link_libraries(test_${TEST_NAME} PRIVATE GigaVector m pthread)
+        if(WIN32)
+            target_link_libraries(test_${TEST_NAME} PRIVATE GigaVector)
+        else()
+            target_link_libraries(test_${TEST_NAME} PRIVATE GigaVector m pthread)
+        endif()
         add_test(NAME ${TEST_NAME} COMMAND test_${TEST_NAME})
     endforeach()
 endif()
@@ -193,7 +207,11 @@ if(BUILD_BENCHMARKS)
     foreach(BENCH_SRC ${BENCHMARK_SOURCES})
         get_filename_component(BENCH_NAME ${BENCH_SRC} NAME_WE)
         add_executable(${BENCH_NAME} ${BENCH_SRC})
-        target_link_libraries(${BENCH_NAME} PRIVATE GigaVector m)
+        if(WIN32)
+            target_link_libraries(${BENCH_NAME} PRIVATE GigaVector)
+        else()
+            target_link_libraries(${BENCH_NAME} PRIVATE GigaVector m)
+        endif()
     endforeach()
 endif()
 

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -3,4 +3,8 @@ include LICENCE.md
 recursive-include src/gigavector *.so
 recursive-include src/gigavector *.dylib
 recursive-include tests *.py
+# C sources bundled by the custom sdist command for Windows source builds
+include _csrc/CMakeLists.txt
+recursive-include _csrc/src *.c
+recursive-include _csrc/include *.h
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -89,7 +89,13 @@ class BuildPyWithMake(build_py):
                 combined_c_flags = " ".join([x for x in [cmake_c_flags, extra_cflags] if x])
 
                 cmake_gen = _cmake_generator(env)
-                is_single_config = bool(cmake_gen)  # VS generators are multi-config
+                # Multi-config generators (Visual Studio, Ninja Multi-Config) pass
+                # --config at build time; single-config generators (MinGW Makefiles,
+                # Ninja, NMake) require CMAKE_BUILD_TYPE at configure time.
+                _MULTI_CONFIG = {"Visual Studio", "Ninja Multi-Config", "Xcode"}
+                is_multi_config = not cmake_gen or any(
+                    cmake_gen.startswith(mc) for mc in _MULTI_CONFIG if mc
+                ) or cmake_gen == ""
 
                 cmake_args = [
                     "cmake", "-S", str(repo_root), "-B", str(build_dir),
@@ -97,6 +103,7 @@ class BuildPyWithMake(build_py):
                 ]
                 if cmake_gen:
                     cmake_args += ["-G", cmake_gen]
+                if not is_multi_config:
                     # Single-config generators need CMAKE_BUILD_TYPE at configure time.
                     cmake_args += ["-DCMAKE_BUILD_TYPE=Release"]
                 if combined_c_flags:
@@ -105,8 +112,8 @@ class BuildPyWithMake(build_py):
                 subprocess.check_call(cmake_args, env=env)
 
                 build_cmd = ["cmake", "--build", str(build_dir)]
-                if not is_single_config:
-                    # Multi-config generators (Visual Studio) need --config at build time.
+                if is_multi_config:
+                    # Multi-config generators select the config at build time.
                     build_cmd += ["--config", "Release"]
                 subprocess.check_call(build_cmd, env=env)
 
@@ -158,18 +165,16 @@ class sdist(_sdist):
 
     def run(self):
         repo_root = Path(__file__).resolve().parent.parent
-        bundled = False
-        if (repo_root / "CMakeLists.txt").exists():
-            if _CSRC_DIR.exists():
-                shutil.rmtree(_CSRC_DIR)
-            shutil.copytree(repo_root / "src", _CSRC_DIR / "src")
-            shutil.copytree(repo_root / "include", _CSRC_DIR / "include")
-            shutil.copy2(repo_root / "CMakeLists.txt", _CSRC_DIR / "CMakeLists.txt")
-            bundled = True
         try:
+            if (repo_root / "CMakeLists.txt").exists():
+                if _CSRC_DIR.exists():
+                    shutil.rmtree(_CSRC_DIR)
+                shutil.copytree(repo_root / "src", _CSRC_DIR / "src")
+                shutil.copytree(repo_root / "include", _CSRC_DIR / "include")
+                shutil.copy2(repo_root / "CMakeLists.txt", _CSRC_DIR / "CMakeLists.txt")
             super().run()
         finally:
-            if bundled and _CSRC_DIR.exists():
+            if _CSRC_DIR.exists():
                 shutil.rmtree(_CSRC_DIR)
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -8,13 +8,57 @@ import glob
 from setuptools import setup
 from setuptools.command.build_py import build_py
 from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
+from setuptools.command.sdist import sdist as _sdist
+
+# Directory inside the python/ tree where C sources are bundled for sdist builds.
+_CSRC_DIR = Path(__file__).resolve().parent / "_csrc"
+
+
+def _find_repo_root() -> Path:
+    """Locate the directory containing CMakeLists.txt.
+
+    Handles two layouts:
+      - git checkout: setup.py lives in <repo>/python/, CMakeLists.txt is at <repo>/
+      - sdist:        C sources are bundled into python/_csrc/ by the custom sdist command
+    """
+    setup_dir = Path(__file__).resolve().parent
+    for candidate in [setup_dir.parent, _CSRC_DIR]:
+        if (candidate / "CMakeLists.txt").exists():
+            return candidate
+    raise FileNotFoundError(
+        "CMakeLists.txt not found. When building on Windows from an sdist, "
+        "the sdist must have been created from a full git checkout so that C "
+        "sources are bundled inside _csrc/."
+    )
+
+
+def _cmake_generator(env: dict) -> str:
+    """Return the CMake generator to use on Windows, or '' to let CMake decide.
+
+    Prefer MSVC (Visual Studio) over MinGW to avoid shipping MinGW runtime DLLs
+    (libgcc_s_seh-1.dll, libwinpthread-1.dll, etc.) alongside the package.
+    Users can always override via the CMAKE_GENERATOR environment variable.
+    """
+    forced = env.get("CMAKE_GENERATOR", "")
+    if forced:
+        return forced
+
+    # If MSVC cl.exe is on PATH (or a VS dev-prompt set VCINSTALLDIR /
+    # VCToolsInstallDir), let CMake auto-select the Visual Studio generator.
+    if shutil.which("cl") or env.get("VCINSTALLDIR") or env.get("VCToolsInstallDir"):
+        return ""  # CMake will pick the VS generator automatically
+
+    # No MSVC found — fall back to MinGW Makefiles if gcc is available.
+    if shutil.which("gcc") or shutil.which("mingw32-make"):
+        return "MinGW Makefiles"
+
+    return ""  # let CMake figure it out
 
 
 class BuildPyWithMake(build_py):
     """Run `make lib` in the repository root and copy the .so into the package."""
 
     def run(self):
-        repo_root = Path(__file__).resolve().parent.parent
         pkg_dir = Path(__file__).resolve().parent / "src" / "gigavector"
         if os.name == "nt":
             lib_filename = "GigaVector.dll"
@@ -34,7 +78,8 @@ class BuildPyWithMake(build_py):
 
             if os.name == "nt":
                 self.announce("Building GigaVector shared library via CMake (Windows)", level=3)
-                build_dir = repo_root / "build-cmake-py"
+                repo_root = _find_repo_root()
+                build_dir = Path(__file__).resolve().parent / "build-cmake-py"
                 build_dir.mkdir(parents=True, exist_ok=True)
 
                 env = os.environ.copy()
@@ -43,26 +88,29 @@ class BuildPyWithMake(build_py):
                 cmake_c_flags = env.get("CMAKE_C_FLAGS", "").strip()
                 combined_c_flags = " ".join([x for x in [cmake_c_flags, extra_cflags] if x])
 
+                cmake_gen = _cmake_generator(env)
+                is_single_config = bool(cmake_gen)  # VS generators are multi-config
+
                 cmake_args = [
                     "cmake", "-S", str(repo_root), "-B", str(build_dir),
                     "-DBUILD_TESTS=OFF", "-DBUILD_BENCHMARKS=OFF",
-                    "-DCMAKE_BUILD_TYPE=Release",
                 ]
-                # Allow callers to force a specific generator (e.g. MinGW Makefiles)
-                cmake_gen = env.get("CMAKE_GENERATOR", "")
                 if cmake_gen:
                     cmake_args += ["-G", cmake_gen]
+                    # Single-config generators need CMAKE_BUILD_TYPE at configure time.
+                    cmake_args += ["-DCMAKE_BUILD_TYPE=Release"]
                 if combined_c_flags:
                     cmake_args.append(f"-DCMAKE_C_FLAGS={combined_c_flags}")
 
                 subprocess.check_call(cmake_args, env=env)
-                build_cmd = ["cmake", "--build", str(build_dir), "--config", "Release"]
-                if cmake_gen:
-                    # Single-config generators (MinGW Makefiles) don't use --config
-                    build_cmd = ["cmake", "--build", str(build_dir)]
+
+                build_cmd = ["cmake", "--build", str(build_dir)]
+                if not is_single_config:
+                    # Multi-config generators (Visual Studio) need --config at build time.
+                    build_cmd += ["--config", "Release"]
                 subprocess.check_call(build_cmd, env=env)
 
-                # MinGW prefixes the DLL with "lib"; MSVC does not.
+                # MSVC puts the DLL in <build>/Release/; MinGW puts it at <build>/ with a lib prefix.
                 candidates = [
                     build_dir / "Release" / "GigaVector.dll",
                     build_dir / "GigaVector.dll",
@@ -70,13 +118,15 @@ class BuildPyWithMake(build_py):
                 ]
                 lib_path = next((p for p in candidates if p.exists()), None)
                 if lib_path is None:
-                    hits = glob.glob(str(build_dir / "**" / "GigaVector.dll"), recursive=True)
-                    if hits:
-                        lib_path = Path(hits[0])
+                    hits = glob.glob(str(build_dir / "**" / "*.dll"), recursive=True)
+                    dll_hits = [h for h in hits if "GigaVector" in Path(h).name]
+                    if dll_hits:
+                        lib_path = Path(dll_hits[0])
                 if lib_path is None:
                     raise FileNotFoundError(f"{lib_filename} not found after CMake build in {build_dir}")
 
             else:
+                repo_root = _find_repo_root()
                 # POSIX: build via Makefile
                 candidate = repo_root / "build" / "lib" / lib_filename
                 if candidate.exists():
@@ -103,6 +153,26 @@ class BuildPyWithMake(build_py):
         super().run()
 
 
+class sdist(_sdist):
+    """Bundle C sources into the sdist so Windows can build from source."""
+
+    def run(self):
+        repo_root = Path(__file__).resolve().parent.parent
+        bundled = False
+        if (repo_root / "CMakeLists.txt").exists():
+            if _CSRC_DIR.exists():
+                shutil.rmtree(_CSRC_DIR)
+            shutil.copytree(repo_root / "src", _CSRC_DIR / "src")
+            shutil.copytree(repo_root / "include", _CSRC_DIR / "include")
+            shutil.copy2(repo_root / "CMakeLists.txt", _CSRC_DIR / "CMakeLists.txt")
+            bundled = True
+        try:
+            super().run()
+        finally:
+            if bundled and _CSRC_DIR.exists():
+                shutil.rmtree(_CSRC_DIR)
+
+
 class bdist_wheel(_bdist_wheel):
     def initialize_options(self):
         super().initialize_options()
@@ -116,6 +186,8 @@ class bdist_wheel(_bdist_wheel):
         self.root_is_pure = False
 
 
-setup(cmdclass={"build_py": BuildPyWithMake, "bdist_wheel": bdist_wheel})
-
-
+setup(cmdclass={
+    "build_py": BuildPyWithMake,
+    "bdist_wheel": bdist_wheel,
+    "sdist": sdist,
+})

--- a/src/api/python_compat.c
+++ b/src/api/python_compat.c
@@ -1,6 +1,19 @@
 #include "storage/database.h"
 #include "storage/wal.h"
+#include "storage/memory_layer.h"
+#include "storage/memory_extraction.h"
+#include "storage/backup.h"
+#include "schema/vector.h"
+#include "schema/metadata.h"
+#include "index/kdtree.h"
+#include "multimodal/llm.h"
+#include "multimodal/embedding.h"
+#include "features/context_graph.h"
+#include "specialized/gpu.h"
+#include "api/server.h"
 #include "admin/replication.h"
+#include "admin/shard.h"
+#include "admin/cluster.h"
 
 GV_Database *gv_db_open(const char *filepath, size_t dimension, GV_IndexType index_type) {
     return db_open(filepath, dimension, index_type);
@@ -93,5 +106,909 @@ int gv_replication_leader_append_wal(GV_ReplicationManager *mgr, uint64_t entry_
 
 int gv_wal_truncate(GV_WAL *wal) {
     return wal_truncate(wal);
+}
+
+/* ── Database: open variants ── */
+
+GV_Database *gv_db_open_with_ivfflat_config(const char *filepath, size_t dimension,
+                                             GV_IndexType index_type, const GV_IVFFlatConfig *config) {
+    return db_open_with_ivfflat_config(filepath, dimension, index_type, config);
+}
+
+GV_Database *gv_db_open_with_pq_config(const char *filepath, size_t dimension,
+                                        GV_IndexType index_type, const GV_PQConfig *config) {
+    return db_open_with_pq_config(filepath, dimension, index_type, config);
+}
+
+GV_Database *gv_db_open_with_lsh_config(const char *filepath, size_t dimension,
+                                         GV_IndexType index_type, const GV_LSHConfig *config) {
+    return db_open_with_lsh_config(filepath, dimension, index_type, config);
+}
+
+GV_Database *gv_db_open_from_memory(const void *data, size_t size,
+                                     size_t dimension, GV_IndexType index_type) {
+    return db_open_from_memory(data, size, dimension, index_type);
+}
+
+GV_Database *gv_db_open_mmap(const char *filepath, size_t dimension, GV_IndexType index_type) {
+    return db_open_mmap(filepath, dimension, index_type);
+}
+
+/* ── Database: misc ── */
+
+GV_IndexType gv_index_suggest(size_t dimension, size_t expected_count) {
+    return index_suggest(dimension, expected_count);
+}
+
+void gv_db_get_stats(const GV_Database *db, GV_DBStats *out) {
+    db_get_stats(db, out);
+}
+
+void gv_db_set_cosine_normalized(GV_Database *db, int enabled) {
+    db_set_cosine_normalized(db, enabled);
+}
+
+/* ── Database: vector CRUD ── */
+
+int gv_db_delete_vector_by_index(GV_Database *db, size_t vector_index) {
+    return db_delete_vector_by_index(db, vector_index);
+}
+
+int gv_db_update_vector(GV_Database *db, size_t vector_index,
+                        const float *new_data, size_t dimension) {
+    return db_update_vector(db, vector_index, new_data, dimension);
+}
+
+int gv_db_update_vector_metadata(GV_Database *db, size_t vector_index,
+                                 const char *const *metadata_keys,
+                                 const char *const *metadata_values,
+                                 size_t metadata_count) {
+    return db_update_vector_metadata(db, vector_index, metadata_keys, metadata_values, metadata_count);
+}
+
+int gv_db_ivfflat_train(GV_Database *db, const float *data, size_t count, size_t dimension) {
+    return db_ivfflat_train(db, data, count, dimension);
+}
+
+int gv_db_pq_train(GV_Database *db, const float *data, size_t count, size_t dimension) {
+    return db_pq_train(db, data, count, dimension);
+}
+
+int gv_db_add_vectors(GV_Database *db, const float *data, size_t count, size_t dimension) {
+    return db_add_vectors(db, data, count, dimension);
+}
+
+int gv_db_add_vectors_with_metadata(GV_Database *db, const float *data,
+                                    const char *const *keys, const char *const *values,
+                                    size_t count, size_t dimension) {
+    return db_add_vectors_with_metadata(db, data, keys, values, count, dimension);
+}
+
+int gv_db_add_sparse_vector(GV_Database *db, const uint32_t *indices, const float *values,
+                             size_t nnz, size_t dimension,
+                             const char *metadata_key, const char *metadata_value) {
+    return db_add_sparse_vector(db, indices, values, nnz, dimension, metadata_key, metadata_value);
+}
+
+int gv_db_upsert(GV_Database *db, size_t vector_index, const float *data, size_t dimension) {
+    return db_upsert(db, vector_index, data, dimension);
+}
+
+int gv_db_upsert_with_metadata(GV_Database *db, size_t vector_index,
+                                const float *data, size_t dimension,
+                                const char *const *metadata_keys,
+                                const char *const *metadata_values,
+                                size_t metadata_count) {
+    return db_upsert_with_metadata(db, vector_index, data, dimension,
+                                   metadata_keys, metadata_values, metadata_count);
+}
+
+int gv_db_delete_vectors(GV_Database *db, const size_t *indices, size_t count) {
+    return db_delete_vectors(db, indices, count);
+}
+
+/* ── Database: search ── */
+
+int gv_db_search_with_filter_expr(const GV_Database *db, const float *query_data, size_t k,
+                                   GV_SearchResult *results, GV_DistanceType distance_type,
+                                   const char *filter_expr) {
+    return db_search_with_filter_expr(db, query_data, k, results, distance_type, filter_expr);
+}
+
+int gv_db_search_ivfpq_opts(const GV_Database *db, const float *query_data, size_t k,
+                             GV_SearchResult *results, GV_DistanceType distance_type,
+                             size_t nprobe_override, size_t rerank_top) {
+    return db_search_ivfpq_opts(db, query_data, k, results, distance_type,
+                                nprobe_override, rerank_top);
+}
+
+int gv_db_search_sparse(const GV_Database *db, const uint32_t *indices, const float *values,
+                         size_t nnz, size_t k, GV_SearchResult *results,
+                         GV_DistanceType distance_type) {
+    return db_search_sparse(db, indices, values, nnz, k, results, distance_type);
+}
+
+int gv_db_range_search(const GV_Database *db, const float *query_data, float radius,
+                        GV_SearchResult *results, size_t max_results,
+                        GV_DistanceType distance_type) {
+    return db_range_search(db, query_data, radius, results, max_results, distance_type);
+}
+
+int gv_db_range_search_filtered(const GV_Database *db, const float *query_data, float radius,
+                                 GV_SearchResult *results, size_t max_results,
+                                 GV_DistanceType distance_type,
+                                 const char *filter_key, const char *filter_value) {
+    return db_range_search_filtered(db, query_data, radius, results, max_results,
+                                    distance_type, filter_key, filter_value);
+}
+
+int gv_db_search_with_params(const GV_Database *db, const float *query_data, size_t k,
+                              GV_SearchResult *results, GV_DistanceType distance_type,
+                              const GV_SearchParams *params) {
+    return db_search_with_params(db, query_data, k, results, distance_type, params);
+}
+
+int gv_db_scroll(const GV_Database *db, size_t offset, size_t limit,
+                 GV_ScrollResult *results) {
+    return db_scroll(db, offset, limit, results);
+}
+
+/* ── Database: exact search config ── */
+
+void gv_db_set_exact_search_threshold(GV_Database *db, size_t threshold) {
+    db_set_exact_search_threshold(db, threshold);
+}
+
+void gv_db_set_force_exact_search(GV_Database *db, int enabled) {
+    db_set_force_exact_search(db, enabled);
+}
+
+/* ── Database: resource limits ── */
+
+int gv_db_set_resource_limits(GV_Database *db, const GV_ResourceLimits *limits) {
+    return db_set_resource_limits(db, limits);
+}
+
+void gv_db_get_resource_limits(const GV_Database *db, GV_ResourceLimits *limits) {
+    db_get_resource_limits(db, limits);
+}
+
+size_t gv_db_get_memory_usage(const GV_Database *db) {
+    return db_get_memory_usage(db);
+}
+
+size_t gv_db_get_concurrent_operations(const GV_Database *db) {
+    return db_get_concurrent_operations(db);
+}
+
+/* ── Database: compaction ── */
+
+int gv_db_start_background_compaction(GV_Database *db) {
+    return db_start_background_compaction(db);
+}
+
+void gv_db_stop_background_compaction(GV_Database *db) {
+    db_stop_background_compaction(db);
+}
+
+int gv_db_compact(GV_Database *db) {
+    return db_compact(db);
+}
+
+void gv_db_set_compaction_interval(GV_Database *db, size_t interval_sec) {
+    db_set_compaction_interval(db, interval_sec);
+}
+
+void gv_db_set_wal_compaction_threshold(GV_Database *db, size_t threshold_bytes) {
+    db_set_wal_compaction_threshold(db, threshold_bytes);
+}
+
+void gv_db_set_deleted_ratio_threshold(GV_Database *db, double ratio) {
+    db_set_deleted_ratio_threshold(db, ratio);
+}
+
+/* ── Database: observability ── */
+
+int gv_db_get_detailed_stats(const GV_Database *db, GV_DetailedStats *out) {
+    return db_get_detailed_stats(db, out);
+}
+
+void gv_db_free_detailed_stats(GV_DetailedStats *stats) {
+    db_free_detailed_stats(stats);
+}
+
+int gv_db_health_check(const GV_Database *db) {
+    return db_health_check(db);
+}
+
+void gv_db_record_latency(GV_Database *db, uint64_t latency_us, int is_insert) {
+    db_record_latency(db, latency_us, is_insert);
+}
+
+void gv_db_record_recall(GV_Database *db, double recall) {
+    db_record_recall(db, recall);
+}
+
+/* ── Database: accessors ── */
+
+size_t gv_database_count(const GV_Database *db) {
+    return database_count(db);
+}
+
+size_t gv_database_dimension(const GV_Database *db) {
+    return database_dimension(db);
+}
+
+const float *gv_database_get_vector(const GV_Database *db, size_t index) {
+    return database_get_vector(db, index);
+}
+
+/* ── Database: JSON import/export ── */
+
+int gv_db_export_json(const GV_Database *db, const char *filepath) {
+    return db_export_json(db, filepath);
+}
+
+int gv_db_import_json(GV_Database *db, const char *filepath) {
+    return db_import_json(db, filepath);
+}
+
+/* ── Vector ── */
+
+GV_Vector *gv_vector_create_from_data(size_t dimension, const float *data) {
+    return vector_create_from_data(dimension, data);
+}
+
+int gv_vector_set_metadata(GV_Vector *vector, const char *key, const char *value) {
+    return vector_set_metadata(vector, key, value);
+}
+
+void gv_vector_destroy(GV_Vector *vector) {
+    vector_destroy(vector);
+}
+
+/* ── KD-tree: gv_kdtree_insert has a different signature from the underlying
+   kdtree_insert (which requires SoA storage context). Stub returns -1. ── */
+int gv_kdtree_insert(GV_KDNode **root, GV_Vector *point, size_t depth) {
+    (void)root; (void)point; (void)depth;
+    return -1;
+}
+
+/* ── WAL ── */
+
+int gv_wal_append_insert(GV_WAL *wal, const float *data, size_t dimension,
+                          const char *metadata_key, const char *metadata_value) {
+    return wal_append_insert(wal, data, dimension, metadata_key, metadata_value);
+}
+
+int gv_wal_append_insert_rich(GV_WAL *wal, const float *data, size_t dimension,
+                               const char *const *metadata_keys,
+                               const char *const *metadata_values,
+                               size_t metadata_count) {
+    return wal_append_insert_rich(wal, data, dimension, metadata_keys, metadata_values,
+                                  metadata_count);
+}
+
+/* ── LLM ── */
+
+GV_LLM *gv_llm_create(const GV_LLMConfig *config) {
+    return llm_create(config);
+}
+
+void gv_llm_destroy(GV_LLM *llm) {
+    llm_destroy(llm);
+}
+
+int gv_llm_generate_response(GV_LLM *llm, const GV_LLMMessage *messages,
+                              size_t message_count, const char *response_format,
+                              GV_LLMResponse *response) {
+    return llm_generate_response(llm, messages, message_count, response_format, response);
+}
+
+void gv_llm_response_free(GV_LLMResponse *response) {
+    llm_response_free(response);
+}
+
+void gv_llm_message_free(GV_LLMMessage *message) {
+    llm_message_free(message);
+}
+
+void gv_llm_messages_free(GV_LLMMessage *messages, size_t count) {
+    llm_messages_free(messages, count);
+}
+
+const char *gv_llm_get_last_error(GV_LLM *llm) {
+    return llm_get_last_error(llm);
+}
+
+const char *gv_llm_error_string(int error_code) {
+    return llm_error_string(error_code);
+}
+
+/* ── Embedding ── */
+
+GV_EmbeddingService *gv_embedding_service_create(const GV_EmbeddingConfig *config) {
+    return embedding_service_create(config);
+}
+
+void gv_embedding_service_destroy(GV_EmbeddingService *service) {
+    embedding_service_destroy(service);
+}
+
+int gv_embedding_generate(GV_EmbeddingService *service, const char *text,
+                           size_t *embedding_dim, float **embedding) {
+    return embedding_generate(service, text, embedding_dim, embedding);
+}
+
+int gv_embedding_generate_batch(GV_EmbeddingService *service, const char **texts,
+                                 size_t text_count, size_t **embedding_dims,
+                                 float ***embeddings) {
+    return embedding_generate_batch(service, texts, text_count, embedding_dims, embeddings);
+}
+
+GV_EmbeddingConfig gv_embedding_config_default(void) {
+    return embedding_config_default();
+}
+
+void gv_embedding_config_free(GV_EmbeddingConfig *config) {
+    embedding_config_free(config);
+}
+
+GV_EmbeddingCache *gv_embedding_cache_create(size_t max_size) {
+    return embedding_cache_create(max_size);
+}
+
+void gv_embedding_cache_destroy(GV_EmbeddingCache *cache) {
+    embedding_cache_destroy(cache);
+}
+
+int gv_embedding_cache_get(GV_EmbeddingCache *cache, const char *text,
+                            size_t *embedding_dim, const float **embedding) {
+    return embedding_cache_get(cache, text, embedding_dim, embedding);
+}
+
+int gv_embedding_cache_put(GV_EmbeddingCache *cache, const char *text,
+                            size_t embedding_dim, const float *embedding) {
+    return embedding_cache_put(cache, text, embedding_dim, embedding);
+}
+
+void gv_embedding_cache_clear(GV_EmbeddingCache *cache) {
+    embedding_cache_clear(cache);
+}
+
+void gv_embedding_cache_stats(GV_EmbeddingCache *cache, size_t *size,
+                               uint64_t *hits, uint64_t *misses) {
+    embedding_cache_stats(cache, size, hits, misses);
+}
+
+/* ── Context graph ── */
+
+GV_ContextGraph *gv_context_graph_create(const GV_ContextGraphConfig *config) {
+    return context_graph_create(config);
+}
+
+void gv_context_graph_destroy(GV_ContextGraph *graph) {
+    context_graph_destroy(graph);
+}
+
+int gv_context_graph_extract(GV_ContextGraph *graph, const char *text,
+                              const char *user_id, const char *agent_id,
+                              const char *run_id,
+                              GV_GraphEntity **entities, size_t *entity_count,
+                              GV_GraphRelationship **relationships,
+                              size_t *relationship_count) {
+    return context_graph_extract(graph, text, user_id, agent_id, run_id,
+                                 entities, entity_count, relationships, relationship_count);
+}
+
+int gv_context_graph_add_entities(GV_ContextGraph *graph,
+                                   const GV_GraphEntity *entities, size_t entity_count) {
+    return context_graph_add_entities(graph, entities, entity_count);
+}
+
+int gv_context_graph_add_relationships(GV_ContextGraph *graph,
+                                        const GV_GraphRelationship *relationships,
+                                        size_t relationship_count) {
+    return context_graph_add_relationships(graph, relationships, relationship_count);
+}
+
+int gv_context_graph_search(GV_ContextGraph *graph, const float *query_embedding,
+                             size_t embedding_dim, const char *user_id,
+                             const char *agent_id, const char *run_id,
+                             GV_GraphQueryResult *results, size_t max_results) {
+    return context_graph_search(graph, query_embedding, embedding_dim, user_id,
+                                agent_id, run_id, results, max_results);
+}
+
+int gv_context_graph_get_related(GV_ContextGraph *graph, const char *entity_id,
+                                  size_t max_depth, GV_GraphQueryResult *results,
+                                  size_t max_results) {
+    return context_graph_get_related(graph, entity_id, max_depth, results, max_results);
+}
+
+int gv_context_graph_delete_entities(GV_ContextGraph *graph,
+                                      const char **entity_ids, size_t entity_count) {
+    return context_graph_delete_entities(graph, entity_ids, entity_count);
+}
+
+int gv_context_graph_delete_relationships(GV_ContextGraph *graph,
+                                           const char **relationship_ids,
+                                           size_t relationship_count) {
+    return context_graph_delete_relationships(graph, relationship_ids, relationship_count);
+}
+
+void gv_graph_entity_free(GV_GraphEntity *entity) {
+    graph_entity_free(entity);
+}
+
+void gv_graph_relationship_free(GV_GraphRelationship *relationship) {
+    graph_relationship_free(relationship);
+}
+
+void gv_graph_query_result_free(GV_GraphQueryResult *result) {
+    graph_query_result_free(result);
+}
+
+GV_ContextGraphConfig gv_context_graph_config_default(void) {
+    return context_graph_config_default();
+}
+
+/* ── Memory layer ── */
+
+GV_MemoryLayerConfig gv_memory_layer_config_default(void) {
+    return memory_layer_config_default();
+}
+
+GV_MemoryLayer *gv_memory_layer_create(GV_Database *db, const GV_MemoryLayerConfig *config) {
+    return memory_layer_create(db, config);
+}
+
+void gv_memory_layer_destroy(GV_MemoryLayer *layer) {
+    memory_layer_destroy(layer);
+}
+
+char *gv_memory_add(GV_MemoryLayer *layer, const char *content,
+                    const float *embedding, GV_MemoryMetadata *metadata) {
+    return memory_add(layer, content, embedding, metadata);
+}
+
+char **gv_memory_extract_from_conversation(GV_MemoryLayer *layer, const char *conversation,
+                                            const char *conversation_id,
+                                            float **embeddings, size_t *memory_count) {
+    return memory_extract_from_conversation(layer, conversation, conversation_id,
+                                            embeddings, memory_count);
+}
+
+char **gv_memory_extract_from_text(GV_MemoryLayer *layer, const char *text,
+                                    const char *source, float **embeddings,
+                                    size_t *memory_count) {
+    return memory_extract_from_text(layer, text, source, embeddings, memory_count);
+}
+
+int gv_memory_extract_candidates_from_conversation_llm(GV_LLM *llm,
+                                                        const char *conversation,
+                                                        const char *conversation_id,
+                                                        int is_agent_memory,
+                                                        const char *custom_prompt,
+                                                        void *candidates,
+                                                        size_t max_candidates,
+                                                        size_t *actual_count) {
+    return memory_extract_candidates_from_conversation_llm(llm, conversation, conversation_id,
+                                                           is_agent_memory, custom_prompt,
+                                                           (GV_MemoryCandidate *)candidates,
+                                                           max_candidates, actual_count);
+}
+
+int gv_memory_consolidate(GV_MemoryLayer *layer, double threshold, int strategy) {
+    return memory_consolidate(layer, threshold, strategy);
+}
+
+int gv_memory_search(GV_MemoryLayer *layer, const float *query_embedding, size_t k,
+                     GV_MemoryResult *results, GV_DistanceType distance_type) {
+    return memory_search(layer, query_embedding, k, results, distance_type);
+}
+
+int gv_memory_search_filtered(GV_MemoryLayer *layer, const float *query_embedding,
+                               size_t k, GV_MemoryResult *results,
+                               GV_DistanceType distance_type, int memory_type,
+                               const char *source, time_t min_timestamp,
+                               time_t max_timestamp) {
+    return memory_search_filtered(layer, query_embedding, k, results, distance_type,
+                                  memory_type, source, min_timestamp, max_timestamp);
+}
+
+int gv_memory_get_related(GV_MemoryLayer *layer, const char *memory_id,
+                           size_t k, GV_MemoryResult *results) {
+    return memory_get_related(layer, memory_id, k, results);
+}
+
+int gv_memory_get(GV_MemoryLayer *layer, const char *memory_id, GV_MemoryResult *result) {
+    return memory_get(layer, memory_id, result);
+}
+
+int gv_memory_update(GV_MemoryLayer *layer, const char *memory_id,
+                     const float *new_embedding, GV_MemoryMetadata *new_metadata) {
+    return memory_update(layer, memory_id, new_embedding, new_metadata);
+}
+
+int gv_memory_delete(GV_MemoryLayer *layer, const char *memory_id) {
+    return memory_delete(layer, memory_id);
+}
+
+void gv_memory_result_free(GV_MemoryResult *result) {
+    memory_result_free(result);
+}
+
+void gv_memory_metadata_free(GV_MemoryMetadata *metadata) {
+    memory_metadata_free(metadata);
+}
+
+/* ── GPU ── */
+
+int gv_gpu_available(void) {
+    return gpu_available();
+}
+
+int gv_gpu_device_count(void) {
+    return gpu_device_count();
+}
+
+int gv_gpu_get_device_info(int device_id, GV_GPUDeviceInfo *info) {
+    return gpu_get_device_info(device_id, info);
+}
+
+void gv_gpu_config_init(GV_GPUConfig *config) {
+    gpu_config_init(config);
+}
+
+GV_GPUContext *gv_gpu_create(const GV_GPUConfig *config) {
+    return gpu_create(config);
+}
+
+void gv_gpu_destroy(GV_GPUContext *ctx) {
+    gpu_destroy(ctx);
+}
+
+int gv_gpu_synchronize(GV_GPUContext *ctx) {
+    return gpu_synchronize(ctx);
+}
+
+GV_GPUIndex *gv_gpu_index_create(GV_GPUContext *ctx, const float *vectors,
+                                   size_t count, size_t dimension) {
+    return gpu_index_create(ctx, vectors, count, dimension);
+}
+
+GV_GPUIndex *gv_gpu_index_from_db(GV_GPUContext *ctx, GV_Database *db) {
+    return gpu_index_from_db(ctx, db);
+}
+
+int gv_gpu_index_add(GV_GPUIndex *index, const float *vectors, size_t count) {
+    return gpu_index_add(index, vectors, count);
+}
+
+int gv_gpu_index_remove(GV_GPUIndex *index, const size_t *indices, size_t count) {
+    return gpu_index_remove(index, indices, count);
+}
+
+int gv_gpu_index_update(GV_GPUIndex *index, const size_t *indices,
+                         const float *vectors, size_t count) {
+    return gpu_index_update(index, indices, vectors, count);
+}
+
+int gv_gpu_index_info(GV_GPUIndex *index, size_t *count, size_t *dimension,
+                       size_t *memory_usage) {
+    return gpu_index_info(index, count, dimension, memory_usage);
+}
+
+void gv_gpu_index_destroy(GV_GPUIndex *index) {
+    gpu_index_destroy(index);
+}
+
+int gv_gpu_compute_distances(GV_GPUContext *ctx, const float *queries,
+                              size_t num_queries, const float *database,
+                              size_t num_vectors, size_t dimension,
+                              GV_GPUDistanceMetric metric, float *distances) {
+    return gpu_compute_distances(ctx, queries, num_queries, database, num_vectors,
+                                 dimension, metric, distances);
+}
+
+int gv_gpu_index_compute_distances(GV_GPUIndex *index, const float *queries,
+                                    size_t num_queries, GV_GPUDistanceMetric metric,
+                                    float *distances) {
+    return gpu_index_compute_distances(index, queries, num_queries, metric, distances);
+}
+
+int gv_gpu_knn_search(GV_GPUContext *ctx, const float *queries, size_t num_queries,
+                       const float *database, size_t num_vectors, size_t dimension,
+                       const GV_GPUSearchParams *params, size_t *indices, float *distances) {
+    return gpu_knn_search(ctx, queries, num_queries, database, num_vectors, dimension,
+                          params, indices, distances);
+}
+
+int gv_gpu_index_knn_search(GV_GPUIndex *index, const float *queries, size_t num_queries,
+                              const GV_GPUSearchParams *params, size_t *indices,
+                              float *distances) {
+    return gpu_index_knn_search(index, queries, num_queries, params, indices, distances);
+}
+
+int gv_gpu_index_search(GV_GPUIndex *index, const float *query,
+                         const GV_GPUSearchParams *params, size_t *indices,
+                         float *distances) {
+    return gpu_index_search(index, query, params, indices, distances);
+}
+
+int gv_gpu_batch_add(GV_GPUContext *ctx, GV_Database *db,
+                      const float *vectors, size_t count) {
+    return gpu_batch_add(ctx, db, vectors, count);
+}
+
+int gv_gpu_batch_search(GV_GPUContext *ctx, GV_Database *db, const float *queries,
+                         size_t num_queries, size_t k, size_t *indices, float *distances) {
+    return gpu_batch_search(ctx, db, queries, num_queries, k, indices, distances);
+}
+
+int gv_gpu_get_stats(GV_GPUContext *ctx, GV_GPUStats *stats) {
+    return gpu_get_stats(ctx, stats);
+}
+
+int gv_gpu_reset_stats(GV_GPUContext *ctx) {
+    return gpu_reset_stats(ctx);
+}
+
+/* ── Server ── */
+
+void gv_server_config_init(GV_ServerConfig *config) {
+    server_config_init(config);
+}
+
+GV_Server *gv_server_create(GV_Database *db, const GV_ServerConfig *config) {
+    return server_create(db, config);
+}
+
+int gv_server_start(GV_Server *server) {
+    return server_start(server);
+}
+
+int gv_server_stop(GV_Server *server) {
+    return server_stop(server);
+}
+
+void gv_server_destroy(GV_Server *server) {
+    server_destroy(server);
+}
+
+int gv_server_is_running(const GV_Server *server) {
+    return server_is_running(server);
+}
+
+int gv_server_get_stats(const GV_Server *server, GV_ServerStats *stats) {
+    return server_get_stats(server, stats);
+}
+
+uint16_t gv_server_get_port(const GV_Server *server) {
+    return server_get_port(server);
+}
+
+/* ── Backup ── */
+
+void gv_backup_options_init(GV_BackupOptions *options) {
+    backup_options_init(options);
+}
+
+void gv_restore_options_init(GV_RestoreOptions *options) {
+    restore_options_init(options);
+}
+
+GV_BackupResult *gv_backup_create(GV_Database *db, const char *backup_path,
+                                   const GV_BackupOptions *options,
+                                   GV_BackupProgressCallback progress, void *user_data) {
+    return backup_create(db, backup_path, options, progress, user_data);
+}
+
+GV_BackupResult *gv_backup_create_from_file(const char *db_path, const char *backup_path,
+                                             const GV_BackupOptions *options,
+                                             GV_BackupProgressCallback progress,
+                                             void *user_data) {
+    return backup_create_from_file(db_path, backup_path, options, progress, user_data);
+}
+
+void gv_backup_result_free(GV_BackupResult *result) {
+    backup_result_free(result);
+}
+
+GV_BackupResult *gv_backup_restore(const char *backup_path, const char *db_path,
+                                    const GV_RestoreOptions *options,
+                                    GV_BackupProgressCallback progress, void *user_data) {
+    return backup_restore(backup_path, db_path, options, progress, user_data);
+}
+
+GV_BackupResult *gv_backup_restore_to_db(const char *backup_path,
+                                          const GV_RestoreOptions *options,
+                                          GV_Database **db) {
+    return backup_restore_to_db(backup_path, options, db);
+}
+
+int gv_backup_read_header(const char *backup_path, GV_BackupHeader *header) {
+    return backup_read_header(backup_path, header);
+}
+
+GV_BackupResult *gv_backup_verify(const char *backup_path, const char *decryption_key) {
+    return backup_verify(backup_path, decryption_key);
+}
+
+int gv_backup_get_info(const char *backup_path, char *info_buf, size_t buf_size) {
+    return backup_get_info(backup_path, info_buf, buf_size);
+}
+
+GV_BackupResult *gv_backup_create_incremental(GV_Database *db, const char *backup_path,
+                                               const char *base_backup_path,
+                                               const GV_BackupOptions *options) {
+    return backup_create_incremental(db, backup_path, base_backup_path, options);
+}
+
+GV_BackupResult *gv_backup_merge(const char *base_backup_path,
+                                  const char **incremental_paths,
+                                  size_t incremental_count, const char *output_path) {
+    return backup_merge(base_backup_path, incremental_paths, incremental_count, output_path);
+}
+
+int gv_backup_compute_checksum(const char *backup_path, char *checksum_out) {
+    return backup_compute_checksum(backup_path, checksum_out);
+}
+
+/* ── Shard ── */
+
+void gv_shard_config_init(GV_ShardConfig *config) {
+    shard_config_init(config);
+}
+
+GV_ShardManager *gv_shard_manager_create(const GV_ShardConfig *config) {
+    return shard_manager_create(config);
+}
+
+void gv_shard_manager_destroy(GV_ShardManager *mgr) {
+    shard_manager_destroy(mgr);
+}
+
+int gv_shard_add(GV_ShardManager *mgr, uint32_t shard_id, const char *node_address) {
+    return shard_add(mgr, shard_id, node_address);
+}
+
+int gv_shard_remove(GV_ShardManager *mgr, uint32_t shard_id) {
+    return shard_remove(mgr, shard_id);
+}
+
+int gv_shard_for_vector(GV_ShardManager *mgr, uint64_t vector_id) {
+    return shard_for_vector(mgr, vector_id);
+}
+
+int gv_shard_for_key(GV_ShardManager *mgr, const void *key, size_t key_len) {
+    return shard_for_key(mgr, key, key_len);
+}
+
+int gv_shard_get_info(GV_ShardManager *mgr, uint32_t shard_id, GV_ShardInfo *info) {
+    return shard_get_info(mgr, shard_id, info);
+}
+
+int gv_shard_list(GV_ShardManager *mgr, GV_ShardInfo **shards, size_t *count) {
+    return shard_list(mgr, shards, count);
+}
+
+void gv_shard_free_list(GV_ShardInfo *shards, size_t count) {
+    shard_free_list(shards, count);
+}
+
+int gv_shard_set_state(GV_ShardManager *mgr, uint32_t shard_id, GV_ShardState state) {
+    return shard_set_state(mgr, shard_id, state);
+}
+
+int gv_shard_rebalance_start(GV_ShardManager *mgr) {
+    return shard_rebalance_start(mgr);
+}
+
+int gv_shard_rebalance_status(GV_ShardManager *mgr, double *progress) {
+    return shard_rebalance_status(mgr, progress);
+}
+
+int gv_shard_rebalance_cancel(GV_ShardManager *mgr) {
+    return shard_rebalance_cancel(mgr);
+}
+
+int gv_shard_attach_local(GV_ShardManager *mgr, uint32_t shard_id, GV_Database *db) {
+    return shard_attach_local(mgr, shard_id, db);
+}
+
+GV_Database *gv_shard_get_local_db(GV_ShardManager *mgr, uint32_t shard_id) {
+    return shard_get_local_db(mgr, shard_id);
+}
+
+/* ── Replication (missing wrappers) ── */
+
+GV_ReplicationRole gv_replication_get_role(GV_ReplicationManager *mgr) {
+    return replication_get_role(mgr);
+}
+
+int gv_replication_step_down(GV_ReplicationManager *mgr) {
+    return replication_step_down(mgr);
+}
+
+int gv_replication_request_leadership(GV_ReplicationManager *mgr) {
+    return replication_request_leadership(mgr);
+}
+
+int gv_replication_remove_follower(GV_ReplicationManager *mgr, const char *node_id) {
+    return replication_remove_follower(mgr, node_id);
+}
+
+int gv_replication_list_replicas(GV_ReplicationManager *mgr,
+                                  GV_ReplicaInfo **replicas, size_t *count) {
+    return replication_list_replicas(mgr, replicas, count);
+}
+
+void gv_replication_free_replicas(GV_ReplicaInfo *replicas, size_t count) {
+    replication_free_replicas(replicas, count);
+}
+
+int64_t gv_replication_get_lag(GV_ReplicationManager *mgr) {
+    return replication_get_lag(mgr);
+}
+
+int gv_replication_wait_sync(GV_ReplicationManager *mgr, size_t max_lag,
+                              uint32_t timeout_ms) {
+    return replication_wait_sync(mgr, max_lag, timeout_ms);
+}
+
+int gv_replication_get_stats(GV_ReplicationManager *mgr, GV_ReplicationStats *stats) {
+    return replication_get_stats(mgr, stats);
+}
+
+void gv_replication_free_stats(GV_ReplicationStats *stats) {
+    replication_free_stats(stats);
+}
+
+int gv_replication_is_healthy(GV_ReplicationManager *mgr) {
+    return replication_is_healthy(mgr);
+}
+
+/* ── Cluster ── */
+
+void gv_cluster_config_init(GV_ClusterConfig *config) {
+    cluster_config_init(config);
+}
+
+GV_Cluster *gv_cluster_create(const GV_ClusterConfig *config) {
+    return cluster_create(config);
+}
+
+void gv_cluster_destroy(GV_Cluster *cluster) {
+    cluster_destroy(cluster);
+}
+
+int gv_cluster_start(GV_Cluster *cluster) {
+    return cluster_start(cluster);
+}
+
+int gv_cluster_stop(GV_Cluster *cluster) {
+    return cluster_stop(cluster);
+}
+
+int gv_cluster_get_local_node(GV_Cluster *cluster, GV_NodeInfo *info) {
+    return cluster_get_local_node(cluster, info);
+}
+
+int gv_cluster_get_node(GV_Cluster *cluster, const char *node_id, GV_NodeInfo *info) {
+    return cluster_get_node(cluster, node_id, info);
+}
+
+int gv_cluster_list_nodes(GV_Cluster *cluster, GV_NodeInfo **nodes, size_t *count) {
+    return cluster_list_nodes(cluster, nodes, count);
+}
+
+void gv_cluster_free_node_info(GV_NodeInfo *info) {
+    cluster_free_node_info(info);
+}
+
+void gv_cluster_free_node_list(GV_NodeInfo *nodes, size_t count) {
+    cluster_free_node_list(nodes, count);
 }
 


### PR DESCRIPTION
Fixes #10

## What changed

**CMakeLists.txt**
- Add `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON` so MSVC exports all symbols from the DLL without needing `__declspec(dllexport)` annotations — this matches MinGW's default `--export-all-symbols` behaviour and removes the MinGW runtime dependency (libgcc_s_seh-1.dll, libwinpthread-1.dll, etc.)
- Guard GCC/Clang-style `CMAKE_C_FLAGS_RELEASE/DEBUG` behind `NOT MSVC` (MSVC already has sensible per-config defaults)
- Skip `m` / `pthread` link targets on `WIN32` in tests and benchmarks (they live in the CRT on Windows)

**python/setup.py**
- `_find_repo_root()`: searches `parent.parent` (git checkout) then `_csrc/` (sdist bundle), fixing the "cmake -S receives wrong directory" error on Python 3.14 source builds
- `_cmake_generator()`: prefers MSVC/Visual Studio when `cl.exe` or `VCINSTALLDIR` is present; falls back to `MinGW Makefiles` only when no MSVC is detected
- Fix `--config Release` placement: passed at build time for multi-config (VS) generators, at configure time for single-config (MinGW)
- Custom `sdist` command bundles `CMakeLists.txt`, `src/`, and `include/` into `_csrc/` inside the sdist so Windows users can build from source

**python/MANIFEST.in**
- Include the `_csrc/` tree in the sdist