### PR TITLE
fix: memory safety, error logging, and wheel packaging

### DIFF
--- a/include/api/python_compat.h
+++ b/include/api/python_compat.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "storage/database.h"
+#include "admin/replication.h"
+#include "storage/wal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+GV_Database *gv_db_open(const char *filepath, size_t dimension, GV_IndexType index_type);
+void gv_db_close(GV_Database *db);
+
+int gv_db_add_vector(GV_Database *db, const float *data, size_t dimension);
+int gv_db_add_vector_with_metadata(GV_Database *db, const float *data, size_t dimension,
+                                   const char *metadata_key, const char *metadata_value);
+
+int gv_db_search(const GV_Database *db, const float *query_data, size_t k,
+                 GV_SearchResult *results);
+
+int gv_db_save(const GV_Database *db, const char *filepath);
+int gv_db_delete_vector_by_index(GV_Database *db, size_t vector_index);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/api/python_compat.h
+++ b/include/api/python_compat.h
@@ -16,7 +16,7 @@ int gv_db_add_vector_with_metadata(GV_Database *db, const float *data, size_t di
                                    const char *metadata_key, const char *metadata_value);
 
 int gv_db_search(const GV_Database *db, const float *query_data, size_t k,
-                 GV_SearchResult *results);
+                 GV_SearchResult *results, GV_DistanceType distance_type);
 
 int gv_db_save(const GV_Database *db, const char *filepath);
 int gv_db_delete_vector_by_index(GV_Database *db, size_t vector_index);

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -43,11 +43,11 @@ gigavector = [
 	"GigaVector.dll",
 	
 	"dashboard/frontend/index.html",
-	"dashboard/frontend/assets/*",
-	"dashboard/frontend/src/*",
-	"dashboard/frontend/styles/*",
-	
-	"dashboard/backend/*"
+	"dashboard/frontend/assets/**/*",
+	"dashboard/frontend/src/**/*",
+	"dashboard/frontend/styles/**/*",
+
+	"dashboard/backend/**/*"
 	]
 
 

--- a/src/admin/cdc.c
+++ b/src/admin/cdc.c
@@ -12,6 +12,7 @@
 #include "admin/cdc.h"
 #include "core/utils.h"
 
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -131,7 +132,11 @@ GV_CDCStream *cdc_create(const GV_CDCConfig *config) {
 
     if (stream->persist_to_file && stream->log_path) {
         stream->log_fp = fopen(stream->log_path, "ab");
-        /* Failure to open is non-fatal; persistence is best-effort. */
+        if (!stream->log_fp) {
+            fprintf(stderr, "cdc_create: failed to open log file '%s': %s\n",
+                    stream->log_path, strerror(errno));
+            stream->persist_to_file = 0;
+        }
     }
 
     if (pthread_mutex_init(&stream->mutex, NULL) != 0) {

--- a/src/features/sql.c
+++ b/src/features/sql.c
@@ -14,7 +14,7 @@
 
 /* Constants */
 
-#define GV_SQL_ERROR_SIZE      512
+#define GV_SQL_ERROR_SIZE      1024
 #define GV_SQL_MAX_QUERY_DIMS  16384
 #define GV_SQL_MAX_TOKENS      4096
 

--- a/src/search/score_threshold.c
+++ b/src/search/score_threshold.c
@@ -1,4 +1,5 @@
 #include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "search/score_threshold.h"
@@ -48,24 +49,16 @@ int db_search_with_threshold(const void *db, const float *query_data, size_t k,
 
     const GV_Database *database = (const GV_Database *)db;
 
-    /* Use stack-allocated GV_SearchResult array for the search.
-     * For very large k values, this could be problematic, but the specification
-     * says no dynamic allocation. Practically k is small (tens to hundreds). */
-    GV_SearchResult search_results[k];
-    memset(search_results, 0, sizeof(GV_SearchResult) * k);
+    GV_SearchResult *search_results = (GV_SearchResult *)calloc(k, sizeof(GV_SearchResult));
+    if (!search_results) return -1;
 
     int found = db_search(database, query_data, k, search_results,
                              (GV_DistanceType)distance_type);
     if (found < 0) {
+        free(search_results);
         return -1;
     }
 
-    /* Copy results into GV_ThresholdResult format and track index.
-     * GV_SearchResult contains a GV_Vector pointer; we need to derive
-     * a meaningful index. The SoA storage index can be recovered from
-     * the vector pointer offset relative to the database storage. For
-     * simplicity, we use the iteration index (position in search results)
-     * as the result index -- this mirrors the ordering from db_search. */
     size_t passed = 0;
     for (int i = 0; i < found; i++) {
         float dist = search_results[i].distance;
@@ -76,5 +69,6 @@ int db_search_with_threshold(const void *db, const float *query_data, size_t k,
         }
     }
 
+    free(search_results);
     return (int)passed;
 }

--- a/tests/api/test_python_compat.c
+++ b/tests/api/test_python_compat.c
@@ -1,0 +1,68 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "api/python_compat.h"
+#include "storage/database.h"
+
+#define ASSERT(cond, msg) do { if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); return -1; } } while(0)
+
+static int test_open_close(void) {
+    GV_Database *db = gv_db_open(NULL, 4, GV_INDEX_TYPE_FLAT);
+    ASSERT(db != NULL, "gv_db_open should return non-NULL");
+    gv_db_close(db);
+    return 0;
+}
+
+static int test_null_safety(void) {
+    gv_db_close(NULL); /* must not crash */
+    return 0;
+}
+
+static int test_add_and_search(void) {
+    GV_Database *db = gv_db_open(NULL, 4, GV_INDEX_TYPE_FLAT);
+    ASSERT(db != NULL, "create db");
+
+    float vec[4] = {1.0f, 0.0f, 0.0f, 0.0f};
+    int rc = gv_db_add_vector(db, vec, 4);
+    ASSERT(rc == 0, "gv_db_add_vector should succeed");
+
+    GV_SearchResult results[1];
+    int found = gv_db_search(db, vec, 1, results);
+    ASSERT(found == 1, "should find 1 result");
+    ASSERT(results[0].distance >= 0.0f, "distance should be non-negative");
+
+    gv_db_close(db);
+    return 0;
+}
+
+static int test_add_with_metadata(void) {
+    GV_Database *db = gv_db_open(NULL, 4, GV_INDEX_TYPE_FLAT);
+    ASSERT(db != NULL, "create db");
+
+    float vec[4] = {0.5f, 0.5f, 0.5f, 0.5f};
+    int rc = gv_db_add_vector_with_metadata(db, vec, 4, "key", "value");
+    ASSERT(rc == 0, "add with metadata should succeed");
+
+    gv_db_close(db);
+    return 0;
+}
+
+int main(void) {
+    int failed = 0;
+    struct { const char *name; int (*fn)(void); } tests[] = {
+        {"open_close",        test_open_close},
+        {"null_safety",       test_null_safety},
+        {"add_and_search",    test_add_and_search},
+        {"add_with_metadata", test_add_with_metadata},
+    };
+    size_t n = sizeof(tests) / sizeof(tests[0]);
+    for (size_t i = 0; i < n; i++) {
+        if (tests[i].fn() != 0) {
+            fprintf(stderr, "FAILED: %s\n", tests[i].name);
+            failed++;
+        } else {
+            printf("PASS: %s\n", tests[i].name);
+        }
+    }
+    return failed ? 1 : 0;
+}

--- a/tests/api/test_python_compat.c
+++ b/tests/api/test_python_compat.c
@@ -14,7 +14,7 @@ static int test_open_close(void) {
 }
 
 static int test_null_safety(void) {
-    gv_db_close(NULL); /* must not crash */
+    gv_db_close(NULL);
     return 0;
 }
 

--- a/tests/api/test_python_compat.c
+++ b/tests/api/test_python_compat.c
@@ -27,9 +27,9 @@ static int test_add_and_search(void) {
     ASSERT(rc == 0, "gv_db_add_vector should succeed");
 
     GV_SearchResult results[1];
-    int found = gv_db_search(db, vec, 1, results);
+    int found = gv_db_search(db, vec, 1, results, GV_DISTANCE_EUCLIDEAN);
     ASSERT(found == 1, "should find 1 result");
-    ASSERT(results[0].distance >= 0.0f, "distance should be non-negative");
+    ASSERT(results[0].distance >= 0.0f, "euclidean distance should be non-negative");
 
     gv_db_close(db);
     return 0;


### PR DESCRIPTION
## Summary

- Replace VLA with heap allocation in `score_threshold.c` — prevents stack overflow for large `k`
- Log and disable persistence on `fopen` failure in `cdc.c` — was silently ignored before
- Increase SQL error buffer 512→1024 in `sql.c` — prevents truncation when propagating lexer errors
- Use recursive globs (`**/*`) for dashboard frontend assets in `pyproject.toml` — subdirectories were excluded from wheel
- Add missing `include/api/python_compat.h` and basic tests in `tests/api/`

## Test plan
- [ ] Existing CI passes
- [ ] `test_python_compat` runs clean
- [ ] Python wheel includes all dashboard assets