### PR TITLE
fix: fully static Windows DLL — no MinGW runtime deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ jobs:
             mingw-w64-ucrt-x86_64-gcc \
             mingw-w64-ucrt-x86_64-cmake \
             mingw-w64-ucrt-x86_64-make \
-            mingw-w64-ucrt-x86_64-curl
+            mingw-w64-ucrt-x86_64-curl \
+            mingw-w64-ucrt-x86_64-openssl
           echo "C:/msys64/ucrt64/bin" >> "$GITHUB_PATH"
 
       # ── Build (Makefile — Linux/macOS only) ───────────────────────────────

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,18 +51,10 @@ if(WIN32 AND BUILD_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
-# When building with MinGW, prefer static libraries for all third-party deps so
-# the resulting DLL has no dependency on MinGW runtime DLLs (libgcc_s_seh-1.dll,
-# libwinpthread-1.dll, libcurl-4.dll, libssl-3-x64.dll, libcrypto-3-x64.dll).
-# Users without MinGW installed can then load the DLL without any extra installs.
 if(MINGW)
-    # Force find_package to prefer .a over .dll.a import libs
     set(CMAKE_FIND_LIBRARY_SUFFIXES .a .dll.a .lib)
     set(CURL_USE_STATIC_LIBS ON)
     set(OPENSSL_USE_STATIC_LIBS ON)
-
-    # Statically link libgcc, winpthread, curl, ssl, crypto and the Windows
-    # system libs that static curl/openssl depend on.
     set(CMAKE_SHARED_LINKER_FLAGS
         "${CMAKE_SHARED_LINKER_FLAGS} -static-libgcc -Wl,-Bstatic -lpthread -lcurl -lssl -lcrypto -Wl,-Bdynamic -lws2_32 -lcrypt32 -lgdi32 -lbcrypt -lwldap32")
     set(CMAKE_EXE_LINKER_FLAGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,20 @@ if(WIN32 AND BUILD_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
-# When building with MinGW, statically link the GCC and winpthread runtimes so
-# that the resulting DLL has no dependency on libgcc_s_seh-1.dll or
-# libwinpthread-1.dll.  Users without MinGW installed can then load the DLL
-# without any extra runtime installation.
+# When building with MinGW, prefer static libraries for all third-party deps so
+# the resulting DLL has no dependency on MinGW runtime DLLs (libgcc_s_seh-1.dll,
+# libwinpthread-1.dll, libcurl-4.dll, libssl-3-x64.dll, libcrypto-3-x64.dll).
+# Users without MinGW installed can then load the DLL without any extra installs.
 if(MINGW)
+    # Force find_package to prefer .a over .dll.a import libs
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a .dll.a .lib)
+    set(CURL_USE_STATIC_LIBS ON)
+    set(OPENSSL_USE_STATIC_LIBS ON)
+
+    # Statically link libgcc, winpthread, curl, ssl, crypto and the Windows
+    # system libs that static curl/openssl depend on.
     set(CMAKE_SHARED_LINKER_FLAGS
-        "${CMAKE_SHARED_LINKER_FLAGS} -static-libgcc -Wl,-Bstatic -lpthread -Wl,-Bdynamic")
+        "${CMAKE_SHARED_LINKER_FLAGS} -static-libgcc -Wl,-Bstatic -lpthread -lcurl -lssl -lcrypto -Wl,-Bdynamic -lws2_32 -lcrypt32 -lgdi32 -lbcrypt -lwldap32")
     set(CMAKE_EXE_LINKER_FLAGS
         "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc")
 endif()


### PR DESCRIPTION
## Problem

`ldd GigaVector.dll` showed three MinGW runtime DLLs that users must have installed:
- `libwinpthread-1.dll` — pthreads runtime
- `libssl-3-x64.dll` / `libcrypto-3-x64.dll` — OpenSSL
- `libcurl-4.dll` — **not found** (crash on import)

## Changes

**CMakeLists.txt** — when `MINGW` is detected:
- Set `CMAKE_FIND_LIBRARY_SUFFIXES` to prefer `.a` over `.dll.a` so `find_package(CURL/OpenSSL)` picks up static archives
- Set `CURL_USE_STATIC_LIBS=ON` and `OPENSSL_USE_STATIC_LIBS=ON`
- Extend `CMAKE_SHARED_LINKER_FLAGS` to statically link `pthread`, `curl`, `ssl`, `crypto` plus the Windows system libs they need when static (`ws2_32`, `crypt32`, `gdi32`, `bcrypt`, `wldap32`)

**ci.yml** — add `mingw-w64-ucrt-x86_64-openssl` to the MSYS2 pacman install so static OpenSSL archives are available at build time.

## Result

After this fix `ldd GigaVector.dll` should show only Windows system DLLs — no MinGW paths required.