### PR TITLE
fix: bugs, security, and test improvements across index, storage, and build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 build/
 build-cmake/
 build_warnings/
+build-audit/
+build-fix/
+build-san-test/
+build-win/
+build-win-cmake/
+build-win-test/
 
 # CMake artifacts in source root
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,18 @@ if(BUILD_TESTS)
         endif()
         add_test(NAME ${TEST_NAME} COMMAND test_${TEST_NAME})
     endforeach()
+
+    # Shell-based tests (skip gracefully when prerequisites are absent)
+    find_program(BASH_EXECUTABLE bash)
+    if(BASH_EXECUTABLE AND NOT WIN32)
+        add_test(NAME corrupt_wal
+            COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/corrupt_wal.sh)
+        set_tests_properties(corrupt_wal PROPERTIES SKIP_RETURN_CODE 77)
+
+        add_test(NAME corrupt_snapshot
+            COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/corrupt_snapshot.sh)
+        set_tests_properties(corrupt_snapshot PROPERTIES SKIP_RETURN_CODE 77)
+    endif()
 endif()
 
 # Benchmarks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,19 +227,26 @@ install(TARGETS gvbackup gvrestore gvinspect
 # Sanitizers — ASAN and TSAN are mutually exclusive; ENABLE_SANITIZERS uses ASAN+UBSAN.
 # Use ENABLE_TSAN for a separate thread-sanitizer build.
 option(ENABLE_TSAN "Enable ThreadSanitizer (incompatible with ASAN)" OFF)
+
+# Collect sanitizer/coverage flags into an INTERFACE target so they are applied
+# per-target via transitive linkage rather than polluting global flag variables.
+add_library(gv_instrumentation_flags INTERFACE)
+
 if(ENABLE_TSAN)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=thread -fno-omit-frame-pointer")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")
+    target_compile_options(gv_instrumentation_flags INTERFACE -fsanitize=thread -fno-omit-frame-pointer)
+    target_link_options(gv_instrumentation_flags INTERFACE -fsanitize=thread)
 elseif(ENABLE_SANITIZERS)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address -fsanitize=undefined")
+    target_compile_options(gv_instrumentation_flags INTERFACE -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer)
+    target_link_options(gv_instrumentation_flags INTERFACE -fsanitize=address -fsanitize=undefined)
 endif()
 
-# Coverage
 if(ENABLE_COVERAGE)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -O0")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    target_compile_options(gv_instrumentation_flags INTERFACE --coverage -O0)
+    target_link_options(gv_instrumentation_flags INTERFACE --coverage)
 endif()
+
+# Propagate instrumentation flags to GigaVector and all targets that link it.
+target_link_libraries(GigaVector PUBLIC gv_instrumentation_flags)
 
 # Tests
 if(BUILD_TESTS)

--- a/include/core/utils.h
+++ b/include/core/utils.h
@@ -39,6 +39,21 @@ static inline char *gv_dup_cstr(const char *s) {
     return gv_strdup(s);
 }
 
+/* CRC-32 (polynomial 0xEDB88320) */
+static inline uint32_t gv_crc32_init(void) { return 0xFFFFFFFFu; }
+
+static inline uint32_t gv_crc32_update(uint32_t crc, const void *data, size_t len) {
+    const uint8_t *p = (const uint8_t *)data;
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= p[i];
+        for (int k = 0; k < 8; ++k)
+            crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
+    }
+    return crc;
+}
+
+static inline uint32_t gv_crc32_finish(uint32_t crc) { return crc ^ 0xFFFFFFFFu; }
+
 /* DJB2 string hash */
 static inline uint32_t hash_str(const char *s) {
     uint32_t h = 5381;

--- a/include/storage/database.h
+++ b/include/storage/database.h
@@ -457,6 +457,18 @@ int db_search_filtered(const GV_Database *db, const float *query_data, size_t k,
                           const char *filter_key, const char *filter_value);
 
 /**
+ * @brief Free search results returned by any db_search* function.
+ *
+ * Releases the GV_Vector (including its data and metadata) pointed to by each
+ * result entry. Safe to call when results[i].vector is NULL. The caller is
+ * still responsible for freeing the results array itself.
+ *
+ * @param results Array of search results; may be NULL.
+ * @param count   Number of entries in the array.
+ */
+void gv_search_results_free(GV_SearchResult *results, size_t count);
+
+/**
  * @brief Range search: find all vectors within a distance threshold.
  *
  * @param db Database to search; must be non-NULL.

--- a/include/storage/database.h
+++ b/include/storage/database.h
@@ -520,15 +520,6 @@ int db_search_ivfpq_opts(const GV_Database *db, const float *query_data, size_t 
  * @param dimension Vector dimensionality (must match db->dimension).
  * @return 0 on success, -1 on error (no partial rollback).
  */
-/**
- * @brief Add an item.
- *
- * @param db Database instance.
- * @param data Input data buffer.
- * @param count Number of items.
- * @param dimension Vector dimensionality.
- * @return 0 on success, -1 on error.
- */
 int db_add_vectors(GV_Database *db, const float *data, size_t count, size_t dimension);
 
 /**

--- a/include/storage/database.h
+++ b/include/storage/database.h
@@ -921,13 +921,6 @@ int db_export_json(const GV_Database *db, const char *filepath);
  */
 int db_import_json(GV_Database *db, const char *filepath);
 
-/**
- * @brief Free memory allocated by GigaVector (e.g. strings from to_json).
- *
- * @param ptr Pointer to free (safe to call with NULL).
- */
-void free(void *ptr);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/storage/wal.h
+++ b/include/storage/wal.h
@@ -110,18 +110,26 @@ int wal_replay(const char *path, size_t expected_dimension,
  * @brief Replay a WAL file and deliver all metadata entries for each record.
  *
  * Newer API that passes arrays of metadata key/value pairs to the callback.
- * Existing WAL files with single metadata entries remain compatible.
+ * All operation types (INSERT, DELETE, UPDATE) are delivered to the caller.
+ * Pass NULL for on_delete or on_update to skip those record types.
  *
  * @param path WAL file path.
  * @param expected_dimension Dimension the WAL must match.
  * @param expected_index_type Index type; validated when nonzero (skipped for old WALs).
  * @param on_insert Callback invoked per insert record; must return 0 on success.
- * @return 0 on success, -1 on I/O or validation failure, or if the callback fails.
+ * @param on_delete Optional callback invoked per delete record; NULL to skip.
+ * @param on_update Optional callback invoked per update record; NULL to skip.
+ * @param ctx Caller context passed to all callbacks.
+ * @return 0 on success, -1 on I/O or validation failure, or if a callback fails.
  */
 int wal_replay_rich(const char *path, size_t expected_dimension,
                        int (*on_insert)(void *ctx, const float *data, size_t dimension,
                                         const char *const *metadata_keys, const char *const *metadata_values,
                                         size_t metadata_count),
+                       int (*on_delete)(void *ctx, size_t vector_index),
+                       int (*on_update)(void *ctx, size_t vector_index, const float *data,
+                                        size_t dimension, const char *const *metadata_keys,
+                                        const char *const *metadata_values, size_t metadata_count),
                        void *ctx, uint32_t expected_index_type);
 
 /**

--- a/main.c
+++ b/main.c
@@ -113,23 +113,18 @@ int main(int argc, char **argv) {
 
     printf("Index: %s | dim=%zu\n", index_type == GV_INDEX_TYPE_KDTREE ? "kdtree" :
                                    index_type == GV_INDEX_TYPE_HNSW ? "hnsw" : "ivfpq", dim);
-    GV_Database *db = db_open(db_path, dim, index_type);
-    if (db == NULL) {
-        fprintf(stderr, "Error: Failed to create database (check WAL/index compatibility)\n");
-        return EXIT_FAILURE;
-    }
-
+    GV_Database *db;
     if (index_type == GV_INDEX_TYPE_IVFPQ) {
         GV_IVFPQConfig cfg = {.nlist = ivf_nlist, .m = ivf_m, .nbits = ivf_nbits,
                               .nprobe = ivf_nprobe, .train_iters = 20,
                               .default_rerank = ivf_rerank, .use_cosine = ivf_cosine};
-        gv_ivfpq_destroy(db->hnsw_index);
-        db->hnsw_index = gv_ivfpq_create(dim, &cfg);
-        if (!db->hnsw_index) {
-            fprintf(stderr, "Error: IVF-PQ create failed\n");
-            db_close(db);
-            return EXIT_FAILURE;
-        }
+        db = db_open_with_ivfpq_config(db_path, dim, index_type, &cfg);
+    } else {
+        db = db_open(db_path, dim, index_type);
+    }
+    if (db == NULL) {
+        fprintf(stderr, "Error: Failed to create database (check WAL/index compatibility)\n");
+        return EXIT_FAILURE;
     }
 
     size_t train_count = (index_type == GV_INDEX_TYPE_IVFPQ) ? 2048 : 0;

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,6 +38,7 @@ include-package-data = true
 
 [tool.setuptools.package-data]
 gigavector = [
+	"py.typed",
 	"libGigaVector.so",
 	"libGigaVector.dylib",
 	"GigaVector.dll",

--- a/scripts/test-win-vm.sh
+++ b/scripts/test-win-vm.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Test the latest CI-built Windows wheel inside the local Windows VM.
+# Prereq (one-time): run scripts/win-vm-setup-ssh.ps1 inside the VM as Administrator.
+#
+# Usage: ./scripts/test-win-vm.sh [win_username]
+
+set -euo pipefail
+
+WIN_USER="${1:-}"
+SSH_PORT=2222
+REPO="jaywyawhare/GigaVector"
+
+if [[ -z "$WIN_USER" ]]; then
+    echo "Usage: $0 <windows_username>"
+    exit 1
+fi
+
+SSH="ssh -p $SSH_PORT -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no ${WIN_USER}@localhost"
+SCP="scp -P $SSH_PORT -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no"
+
+echo "==> Fetching latest Windows wheel artifact from CI..."
+RUN_ID=$(gh api "repos/$REPO/actions/runs?branch=master&status=success&per_page=5" \
+    --jq '.workflow_runs[] | select(.name=="Publish to PyPI") | .id' | head -1)
+
+if [[ -z "$RUN_ID" ]]; then
+    echo "No successful 'Publish to PyPI' run found. Trying 'Build Python wheels'..."
+    RUN_ID=$(gh api "repos/$REPO/actions/runs?branch=master&status=success&per_page=5" \
+        --jq '.workflow_runs[] | select(.name=="Build Python wheels") | .id' | head -1)
+fi
+
+echo "==> Run ID: $RUN_ID"
+
+ARTIFACT_URL=$(gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" \
+    --jq '.artifacts[] | select(.name | test("windows")) | .archive_download_url' | head -1)
+
+echo "==> Downloading Windows wheel artifact..."
+TMP_DIR=$(mktemp -d)
+gh api "$ARTIFACT_URL" > "$TMP_DIR/windows-wheel.zip"
+unzip -q "$TMP_DIR/windows-wheel.zip" -d "$TMP_DIR/wheel/"
+
+WHEEL_FILE=$(ls "$TMP_DIR/wheel/"*win_amd64*.whl 2>/dev/null | head -1)
+if [[ -z "$WHEEL_FILE" ]]; then
+    echo "ERROR: no win_amd64 wheel found in artifact"
+    ls "$TMP_DIR/wheel/"
+    exit 1
+fi
+echo "==> Wheel: $(basename "$WHEEL_FILE")"
+
+echo "==> Copying wheel to Windows VM..."
+$SCP "$WHEEL_FILE" "${WIN_USER}@localhost:C:/Users/${WIN_USER}/gigavector_test.whl"
+
+echo "==> Installing and testing in Windows VM..."
+$SSH "python -m pip install --force-reinstall C:/Users/${WIN_USER}/gigavector_test.whl && python -c \"
+import gigavector
+db = gigavector.GigaVectorDB(':memory:')
+v = gigavector.Vector([1.0, 0.0, 0.0])
+db.insert(v, {'tag': 'test'})
+results = db.search([1.0, 0.0, 0.0], top_k=1)
+print('PASS: found', len(results), 'result(s)')
+print('Result:', results)
+\""
+
+echo ""
+echo "==> Cleaning up..."
+rm -rf "$TMP_DIR"
+echo "==> Done."

--- a/scripts/win-vm-setup-ssh.ps1
+++ b/scripts/win-vm-setup-ssh.ps1
@@ -1,0 +1,20 @@
+# Run once inside the Windows VM (as Administrator) to enable SSH
+# Then from the Linux host, run: scripts/test-win-vm.sh
+
+# Install OpenSSH Server
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.0.5
+
+# Start + enable SSH service
+Start-Service sshd
+Set-Service -Name sshd -StartupType Automatic
+
+# Allow SSH through firewall
+New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (GigaVector test)' `
+    -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 `
+    -ErrorAction SilentlyContinue
+
+# Print your public key from the Linux host and paste below
+# (or run: ssh-copy-id -p 2222 $env:USERNAME@localhost from the Linux host)
+Write-Host ""
+Write-Host "SSH enabled. Your Windows username: $env:USERNAME"
+Write-Host "From Linux host run: ssh-copy-id -p 2222 -i ~/.ssh/id_ed25519.pub $env:USERNAME@localhost"

--- a/src/api/rest_handlers.c
+++ b/src/api/rest_handlers.c
@@ -7,6 +7,7 @@
 #include "features/json.h"
 #include "storage/database.h"
 #include "core/types.h"
+#include "schema/vector.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -646,6 +647,9 @@ GV_HttpResponse *rest_handle_search(const GV_HandlerContext *ctx,
         json_array_push(results_arr, result_obj);
     }
 
+    for (int i = 0; i < found; i++) {
+        if (results[i].vector) vector_destroy((GV_Vector *)results[i].vector);
+    }
     free(results);
 
     json_object_set(response, "results", results_arr);
@@ -750,9 +754,29 @@ GV_HttpResponse *rest_handle_search_range(const GV_HandlerContext *ctx,
     for (int i = 0; i < found; i++) {
         GV_JsonValue *result_obj = json_object();
         json_object_set(result_obj, "distance", json_number(results[i].distance));
+
+        if (results[i].vector) {
+            GV_JsonValue *data_arr = json_array();
+            for (size_t j = 0; j < ctx->db->dimension; j++) {
+                json_array_push(data_arr, json_number((double)results[i].vector->data[j]));
+            }
+            json_object_set(result_obj, "data", data_arr);
+
+            GV_JsonValue *meta_obj = json_object();
+            GV_Metadata *meta = results[i].vector->metadata;
+            while (meta) {
+                json_object_set(meta_obj, meta->key, json_string(meta->value));
+                meta = meta->next;
+            }
+            json_object_set(result_obj, "metadata", meta_obj);
+        }
+
         json_array_push(results_arr, result_obj);
     }
 
+    for (int i = 0; i < found; i++) {
+        if (results[i].vector) vector_destroy((GV_Vector *)results[i].vector);
+    }
     free(results);
 
     json_object_set(response, "results", results_arr);
@@ -789,6 +813,11 @@ GV_HttpResponse *rest_handle_search_batch(const GV_HandlerContext *ctx,
         json_free(body);
         return rest_response_error(GV_HTTP_400_BAD_REQUEST, "invalid_request",
                                        "Empty queries array");
+    }
+    if (qcount > 10000) {
+        json_free(body);
+        return rest_response_error(GV_HTTP_400_BAD_REQUEST, "invalid_request",
+                                       "Batch query count exceeds maximum of 10000");
     }
 
     /* Parse k */

--- a/src/api/rest_handlers.c
+++ b/src/api/rest_handlers.c
@@ -8,6 +8,7 @@
 #include "storage/database.h"
 #include "core/types.h"
 #include "schema/vector.h"
+#include "search/filter.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -599,10 +600,28 @@ GV_HttpResponse *rest_handle_search(const GV_HandlerContext *ctx,
     /* Check for filter */
     GV_JsonValue *filter = json_object_get(body, "filter");
     if (filter && json_is_object(filter) && json_object_length(filter) > 0) {
+        size_t nfilter = json_object_length(filter);
         GV_JsonEntry *entries = filter->data.object.entries;
-        found = db_search_filtered(ctx->db, query, k, results, distance,
-                                       entries[0].key,
-                                       json_get_string(entries[0].value));
+        if (nfilter == 1) {
+            found = db_search_filtered(ctx->db, query, k, results, distance,
+                                           entries[0].key,
+                                           json_get_string(entries[0].value));
+        } else {
+            /* Build "key == "val" AND key2 == "val2" ..." expression */
+            char expr[2048];
+            size_t pos = 0;
+            for (size_t fi = 0; fi < nfilter && pos < sizeof(expr) - 1; fi++) {
+                const char *val = json_get_string(entries[fi].value);
+                if (!val) continue;
+                int n = snprintf(expr + pos, sizeof(expr) - pos,
+                                 "%s%s == \"%s\"",
+                                 fi > 0 ? " AND " : "",
+                                 entries[fi].key, val);
+                if (n > 0) pos += (size_t)n;
+            }
+            expr[pos] = '\0';
+            found = db_search_with_filter_expr(ctx->db, query, k, results, distance, expr);
+        }
     } else {
         found = db_search(ctx->db, query, k, results, distance);
     }

--- a/src/index/hnsw.c
+++ b/src/index/hnsw.c
@@ -42,6 +42,7 @@ typedef struct {
     int use_acorn;
     size_t acorn_hops;
     GV_DistanceType distance_type;
+    unsigned int rand_seed;
     size_t entry_point;              /**< Node index of entry point (SIZE_MAX = none) */
     size_t count;
     size_t nodes_capacity;
@@ -72,12 +73,16 @@ typedef struct {
 } GV_HNSWIndex;
 
 
-static size_t calculate_level(size_t maxLevel, size_t M) {
+static size_t calculate_level(GV_HNSWIndex *index) {
+#ifndef _WIN32
+    double r = (double)rand_r(&index->rand_seed) / ((double)RAND_MAX + 1.0);
+#else
     double r = (double)rand() / ((double)RAND_MAX + 1.0);
+#endif
     if (r == 0.0) r = 1e-18;
-    double mL = 1.0 / log((double)M);
+    double mL = 1.0 / log((double)index->M);
     size_t level = (size_t)(-log(r) * mL);
-    return (level > maxLevel) ? maxLevel : level;
+    return (level > index->maxLevel) ? index->maxLevel : level;
 }
 
 static int compare_candidates(const void *a, const void *b) {
@@ -285,6 +290,7 @@ void *gv_hnsw_create(size_t dimension, const GV_HNSWConfig *config, GV_SoAStorag
     index->use_acorn = (config && config->use_acorn) ? 1 : 0;
     index->acorn_hops = (config && config->acorn_hops > 0 && config->acorn_hops <= 2) ? config->acorn_hops : 1;
     index->distance_type = config ? config->distance_type : GV_DISTANCE_EUCLIDEAN;
+    index->rand_seed = (unsigned int)(size_t)index ^ 0xdeadbeef;
     index->entry_point = SIZE_MAX;
     index->count = 0;
     index->nodes_capacity = 1024;
@@ -644,7 +650,7 @@ int gv_hnsw_insert(void *index_ptr, GV_Vector *vector) {
 }
 
 static int hnsw_insert_impl(GV_HNSWIndex *index, size_t vector_index, size_t dimension) {
-    size_t level = calculate_level(index->maxLevel, index->M);
+    size_t level = calculate_level(index);
     size_t node_idx = index->count;
 
     if (node_idx >= index->nodes_capacity) {

--- a/src/index/hnsw.c
+++ b/src/index/hnsw.c
@@ -1119,8 +1119,10 @@ int gv_hnsw_search(void *index_ptr, const GV_Vector *query, size_t k,
         const float *node_data = SRCH_VEC(index->nodes[cn].vector_index);
         GV_Metadata *node_meta = soa_storage_get_metadata(index->soa_storage, index->nodes[cn].vector_index);
 
-        if (filter_key && !metadata_get_direct(node_meta, filter_key)) continue;
-        if (filter_key && strcmp(metadata_get_direct(node_meta, filter_key), filter_value) != 0) continue;
+        if (filter_key) {
+            const char *meta_val = metadata_get_direct(node_meta, filter_key);
+            if (!meta_val || !filter_value || strcmp(meta_val, filter_value) != 0) continue;
+        }
 
         GV_Vector *result_vec = (GV_Vector *)malloc(sizeof(GV_Vector));
         if (!result_vec) continue;

--- a/src/security/auth.c
+++ b/src/security/auth.c
@@ -11,6 +11,9 @@
 #include <stdio.h>
 #include <time.h>
 #include <pthread.h>
+#if defined(__linux__)
+#include <sys/random.h>
+#endif
 
 /* Internal Structures */
 
@@ -183,13 +186,16 @@ void auth_to_hex(const unsigned char *hash, size_t hash_len, char *hex_out) {
 /* Random Generation */
 
 static void generate_random_bytes(unsigned char *buf, size_t len) {
+#if defined(__linux__)
+    if (getrandom(buf, len, 0) == (ssize_t)len) return;
+#endif
     FILE *fp = fopen("/dev/urandom", "rb");
     if (fp) {
-        size_t read = fread(buf, 1, len, fp);
+        size_t nread = fread(buf, 1, len, fp);
         fclose(fp);
-        if (read == len) return;
+        if (nread == len) return;
     }
-    /* Fallback to weak random */
+    fprintf(stderr, "GigaVector: WARNING: falling back to weak PRNG for key generation\n");
     for (size_t i = 0; i < len; i++) {
         buf[i] = (unsigned char)(rand() & 0xff);
     }
@@ -685,14 +691,22 @@ int auth_generate_jwt(GV_AuthManager *auth, const char *subject,
     char header_b64[128];
     base64url_encode(header, strlen(header), header_b64);
 
-    /* Build payload */
+    /* Build payload — escape the subject so it can't break JSON structure */
     uint64_t now = (uint64_t)time(NULL);
     uint64_t exp = now + expires_in;
+
+    char escaped_subject[256];
+    size_t ei = 0;
+    for (size_t si = 0; subject[si] && ei + 2 < sizeof(escaped_subject); si++) {
+        if (subject[si] == '"' || subject[si] == '\\') escaped_subject[ei++] = '\\';
+        escaped_subject[ei++] = subject[si];
+    }
+    escaped_subject[ei] = '\0';
 
     char payload[512];
     snprintf(payload, sizeof(payload),
              "{\"sub\":\"%s\",\"iat\":%llu,\"exp\":%llu}",
-             subject, (unsigned long long)now, (unsigned long long)exp);
+             escaped_subject, (unsigned long long)now, (unsigned long long)exp);
 
     char payload_b64[512];
     base64url_encode(payload, strlen(payload), payload_b64);

--- a/src/security/auth.c
+++ b/src/security/auth.c
@@ -248,6 +248,15 @@ void auth_destroy(GV_AuthManager *auth) {
 
 /* API Key Management */
 
+static int cmp_api_key_by_hash(const void *a, const void *b) {
+    return strcmp(((const APIKeyEntry *)a)->key_hash,
+                  ((const APIKeyEntry *)b)->key_hash);
+}
+
+static void auth_sort_keys(GV_AuthManager *auth) {
+    qsort(auth->keys, auth->key_count, sizeof(APIKeyEntry), cmp_api_key_by_hash);
+}
+
 int auth_generate_api_key(GV_AuthManager *auth, const char *description,
                               uint64_t expires_at, char *key_out, char *key_id_out) {
     if (!auth || !key_out || !key_id_out) return -1;
@@ -283,6 +292,7 @@ int auth_generate_api_key(GV_AuthManager *auth, const char *description,
     entry->enabled = 1;
 
     auth->key_count++;
+    auth_sort_keys(auth);
 
     pthread_rwlock_unlock(&auth->rwlock);
     return 0;
@@ -401,32 +411,36 @@ GV_AuthResult auth_verify_api_key(GV_AuthManager *auth, const char *api_key,
 
     uint64_t now = (uint64_t)time(NULL);
 
-    for (size_t i = 0; i < auth->key_count; i++) {
-        if (strcmp(auth->keys[i].key_hash, hash_hex) == 0) {
-            if (!auth->keys[i].enabled) {
-                pthread_rwlock_unlock(&auth->rwlock);
-                return GV_AUTH_INVALID_KEY;
-            }
-            if (auth->keys[i].expires_at > 0 && auth->keys[i].expires_at < now) {
-                pthread_rwlock_unlock(&auth->rwlock);
-                return GV_AUTH_EXPIRED;
-            }
+    APIKeyEntry key;
+    strncpy(key.key_hash, hash_hex, sizeof(key.key_hash) - 1);
+    key.key_hash[sizeof(key.key_hash) - 1] = '\0';
+    APIKeyEntry *found_entry = (APIKeyEntry *)bsearch(&key, auth->keys, auth->key_count,
+                                                       sizeof(APIKeyEntry), cmp_api_key_by_hash);
 
-            if (identity) {
-                memset(identity, 0, sizeof(*identity));
-                identity->key_id = gv_dup_cstr(auth->keys[i].key_id);
-                identity->subject = gv_dup_cstr(auth->keys[i].key_id);
-                identity->auth_time = now;
-                identity->expires_at = auth->keys[i].expires_at;
-            }
+    if (!found_entry) {
+        pthread_rwlock_unlock(&auth->rwlock);
+        return GV_AUTH_INVALID_KEY;
+    }
 
-            pthread_rwlock_unlock(&auth->rwlock);
-            return GV_AUTH_SUCCESS;
-        }
+    if (!found_entry->enabled) {
+        pthread_rwlock_unlock(&auth->rwlock);
+        return GV_AUTH_INVALID_KEY;
+    }
+    if (found_entry->expires_at > 0 && found_entry->expires_at < now) {
+        pthread_rwlock_unlock(&auth->rwlock);
+        return GV_AUTH_EXPIRED;
+    }
+
+    if (identity) {
+        memset(identity, 0, sizeof(*identity));
+        identity->key_id = gv_dup_cstr(found_entry->key_id);
+        identity->subject = gv_dup_cstr(found_entry->key_id);
+        identity->auth_time = now;
+        identity->expires_at = found_entry->expires_at;
     }
 
     pthread_rwlock_unlock(&auth->rwlock);
-    return GV_AUTH_INVALID_KEY;
+    return GV_AUTH_SUCCESS;
 }
 
 /* Base64 URL decoding for JWT verification */

--- a/src/security/crypto.c
+++ b/src/security/crypto.c
@@ -375,23 +375,21 @@ int crypto_encrypt(GV_CryptoContext *ctx, const GV_CryptoKey *key,
     size_t total_len = plaintext_len + pad_len;
     *ciphertext_len = total_len;
 
-    /* CBC mode encryption */
+    /* CBC mode encryption — loop over total_len which includes PKCS7 padding block */
     unsigned char prev_block[16];
     memcpy(prev_block, key->iv, 16);
 
     size_t pos = 0;
-    while (pos < plaintext_len) {
+    while (pos < total_len) {
         unsigned char block[16];
-        size_t block_len = plaintext_len - pos;
+        size_t block_len = (pos < plaintext_len) ? (plaintext_len - pos) : 0;
         if (block_len > 16) block_len = 16;
 
-        memcpy(block, plaintext + pos, block_len);
+        if (block_len > 0) memcpy(block, plaintext + pos, block_len);
 
-        /* PKCS7 padding */
-        if (block_len < 16 || pos + 16 >= total_len) {
-            for (size_t i = block_len; i < 16; i++) {
-                block[i] = (unsigned char)pad_len;
-            }
+        /* PKCS7 padding fills the remainder of the block (or an entire block) */
+        for (size_t i = block_len; i < 16; i++) {
+            block[i] = (unsigned char)pad_len;
         }
 
         /* XOR with previous ciphertext block */

--- a/src/storage/backup.c
+++ b/src/storage/backup.c
@@ -82,7 +82,9 @@ GV_BackupResult *backup_create(GV_Database *db, const char *backup_path,
         return create_result(0, "Failed to create backup file");
     }
 
-    fwrite(BACKUP_MAGIC, 1, BACKUP_MAGIC_LEN, fp);
+    if (fwrite(BACKUP_MAGIC, 1, BACKUP_MAGIC_LEN, fp) != BACKUP_MAGIC_LEN) {
+        fclose(fp); return create_result(0, "Failed to write backup magic");
+    }
 
     GV_BackupHeader header;
     memset(&header, 0, sizeof(header));
@@ -99,20 +101,29 @@ GV_BackupResult *backup_create(GV_Database *db, const char *backup_path,
     header.dimension = db->dimension;
     header.index_type = db->index_type;
 
-    fwrite(&header.version, sizeof(header.version), 1, fp);
-    fwrite(&header.flags, sizeof(header.flags), 1, fp);
-    fwrite(&header.created_at, sizeof(header.created_at), 1, fp);
-    fwrite(&header.vector_count, sizeof(header.vector_count), 1, fp);
-    fwrite(&header.dimension, sizeof(header.dimension), 1, fp);
-    fwrite(&header.index_type, sizeof(header.index_type), 1, fp);
+#define FWRITE1(field) \
+    if (fwrite(&header.field, sizeof(header.field), 1, fp) != 1) { \
+        fclose(fp); return create_result(0, "Failed to write backup header"); \
+    }
+    FWRITE1(version)
+    FWRITE1(flags)
+    FWRITE1(created_at)
+    FWRITE1(vector_count)
+    FWRITE1(dimension)
+    FWRITE1(index_type)
+#undef FWRITE1
 
     /* Placeholder for sizes and checksum (will update at end) */
     long sizes_pos = ftell(fp);
     uint64_t zero = 0;
-    fwrite(&zero, sizeof(zero), 1, fp);
-    fwrite(&zero, sizeof(zero), 1, fp);
-    char checksum_placeholder[65] = {0};
-    fwrite(checksum_placeholder, 1, BACKUP_CHECKSUM_LEN, fp);
+    if (fwrite(&zero, sizeof(zero), 1, fp) != 1 ||
+        fwrite(&zero, sizeof(zero), 1, fp) != 1) {
+        fclose(fp); return create_result(0, "Failed to write backup placeholders");
+    }
+    char checksum_placeholder[64] = {0};
+    if (fwrite(checksum_placeholder, 1, BACKUP_CHECKSUM_LEN, fp) != BACKUP_CHECKSUM_LEN) {
+        fclose(fp); return create_result(0, "Failed to write checksum placeholder");
+    }
 
     uint64_t data_size = 0;
     size_t dimension = database_dimension(db);

--- a/src/storage/database.c
+++ b/src/storage/database.c
@@ -161,24 +161,6 @@ static int read_uint32(FILE *in, uint32_t *value) {
     return (value != NULL && fread(value, sizeof(uint32_t), 1, in) == 1) ? 0 : -1;
 }
 
-static uint32_t crc32_init(void) {
-    return 0xFFFFFFFFu;
-}
-
-static uint32_t crc32_update(uint32_t crc, const void *data, size_t len) {
-    const uint8_t *p = (const uint8_t *)data;
-    for (size_t i = 0; i < len; ++i) {
-        crc ^= p[i];
-        for (int k = 0; k < 8; ++k) {
-            crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
-        }
-    }
-    return crc;
-}
-
-static uint32_t crc32_finish(uint32_t crc) {
-    return crc ^ 0xFFFFFFFFu;
-}
 
 static char *db_build_wal_path(const char *filepath) {
     if (filepath == NULL) {
@@ -702,7 +684,7 @@ GV_Database *db_open(const char *filepath, size_t dimension, GV_IndexType index_
         if (fseek(in, 0, SEEK_SET) != 0) {
             goto load_fail;
         }
-        uint32_t crc = crc32_init();
+        uint32_t crc = gv_crc32_init();
         char buf[65536];
         long remaining = end_pos - (long)sizeof(uint32_t);
         while (remaining > 0) {
@@ -710,10 +692,10 @@ GV_Database *db_open(const char *filepath, size_t dimension, GV_IndexType index_
             if (fread(buf, 1, chunk, in) != chunk) {
                 goto load_fail;
             }
-            crc = crc32_update(crc, buf, chunk);
+            crc = gv_crc32_update(crc, buf, chunk);
             remaining -= (long)chunk;
         }
-        crc = crc32_finish(crc);
+        crc = gv_crc32_finish(crc);
         if (crc != stored_crc) {
             goto load_fail;
         }
@@ -1155,7 +1137,7 @@ GV_Database *db_open_from_memory(const void *data, size_t size,
             free(db);
             return NULL;
         }
-        uint32_t crc = crc32_init();
+        uint32_t crc = gv_crc32_init();
         char buf[65536];
         long remaining = end_pos - (long)sizeof(uint32_t);
         while (remaining > 0) {
@@ -1174,10 +1156,10 @@ GV_Database *db_open_from_memory(const void *data, size_t size,
                 free(db);
                 return NULL;
             }
-            crc = crc32_update(crc, buf, chunk);
+            crc = gv_crc32_update(crc, buf, chunk);
             remaining -= (long)chunk;
         }
-        crc = crc32_finish(crc);
+        crc = gv_crc32_finish(crc);
         if (crc != stored_crc) {
             fclose(in);
             if (db->index_type == GV_INDEX_TYPE_KDTREE) {
@@ -2432,18 +2414,18 @@ int db_save(const GV_Database *db, const char *filepath) {
         if (rf == NULL) {
             status = -1;
         } else {
-            uint32_t crc = crc32_init();
+            uint32_t crc = gv_crc32_init();
             char buf[65536];
             size_t nread = 0;
             while ((nread = fread(buf, 1, sizeof(buf), rf)) > 0) {
-                crc = crc32_update(crc, buf, nread);
+                crc = gv_crc32_update(crc, buf, nread);
             }
             if (ferror(rf)) {
                 status = -1;
             }
             fclose(rf);
             if (status == 0) {
-                crc = crc32_finish(crc);
+                crc = gv_crc32_finish(crc);
                 FILE *af = fopen(out_path, "ab");
                 if (af == NULL || write_uint32(af, crc) != 0 || fclose(af) != 0) {
                     status = -1;

--- a/src/storage/database.c
+++ b/src/storage/database.c
@@ -2652,6 +2652,16 @@ int db_search_batch(const GV_Database *db, const float *queries, size_t qcount, 
     return (int)(qcount * k);
 }
 
+void gv_search_results_free(GV_SearchResult *results, size_t count) {
+    if (!results) return;
+    for (size_t i = 0; i < count; i++) {
+        if (results[i].vector) {
+            vector_destroy((GV_Vector *)results[i].vector);
+            results[i].vector = NULL;
+        }
+    }
+}
+
 int db_search_filtered(const GV_Database *db, const float *query_data, size_t k,
                           GV_SearchResult *results, GV_DistanceType distance_type,
                           const char *filter_key, const char *filter_value) {

--- a/src/storage/database.c
+++ b/src/storage/database.c
@@ -190,10 +190,14 @@ static char *db_build_wal_path(const char *filepath) {
     basename = (basename == NULL) ? filepath : basename + 1;
 
     char buf[1024];
+    int written;
     if (dir_override != NULL && dir_override[0] != '\0') {
-        snprintf(buf, sizeof(buf), "%s/%s.wal", dir_override, basename);
+        written = snprintf(buf, sizeof(buf), "%s/%s.wal", dir_override, basename);
     } else {
-        snprintf(buf, sizeof(buf), "%s.wal", filepath);
+        written = snprintf(buf, sizeof(buf), "%s.wal", filepath);
+    }
+    if (written < 0 || (size_t)written >= sizeof(buf)) {
+        return NULL;
     }
 
     return gv_dup_cstr(buf);

--- a/src/storage/database.c
+++ b/src/storage/database.c
@@ -185,6 +185,22 @@ static char *db_build_wal_path(const char *filepath) {
     return gv_dup_cstr(buf);
 }
 
+static int db_wal_apply_delete(void *ctx, size_t vector_index) {
+    GV_Database *db = (GV_Database *)ctx;
+    if (db == NULL) return -1;
+    return db_delete_vector_by_index(db, vector_index);
+}
+
+static int db_wal_apply_update(void *ctx, size_t vector_index, const float *data,
+                                size_t dimension,
+                                const char *const *metadata_keys, const char *const *metadata_values,
+                                size_t metadata_count) {
+    GV_Database *db = (GV_Database *)ctx;
+    if (db == NULL || data == NULL || dimension != db->dimension) return -1;
+    (void)metadata_keys; (void)metadata_values; (void)metadata_count;
+    return db_update_vector(db, vector_index, data, dimension);
+}
+
 static int db_wal_apply_rich(void *ctx, const float *data, size_t dimension,
                                 const char *const *metadata_keys, const char *const *metadata_values,
                                 size_t metadata_count) {
@@ -736,7 +752,9 @@ GV_Database *db_open(const char *filepath, size_t dimension, GV_IndexType index_
         }
 
         db->wal_replaying = 1;
-        if (wal_replay_rich(db->wal_path, db->dimension, db_wal_apply_rich, db, (uint32_t)db->index_type) != 0) {
+        if (wal_replay_rich(db->wal_path, db->dimension, db_wal_apply_rich,
+                            db_wal_apply_delete, db_wal_apply_update,
+                            db, (uint32_t)db->index_type) != 0) {
             db->wal_replaying = 0;
             wal_close(db->wal);
             db->wal = NULL;

--- a/src/storage/wal.c
+++ b/src/storage/wal.c
@@ -596,6 +596,10 @@ int wal_replay_rich(const char *path, size_t expected_dimension,
                        int (*on_insert)(void *ctx, const float *data, size_t dimension,
                                         const char *const *metadata_keys, const char *const *metadata_values,
                                         size_t metadata_count),
+                       int (*on_delete)(void *ctx, size_t vector_index),
+                       int (*on_update)(void *ctx, size_t vector_index, const float *data,
+                                        size_t dimension, const char *const *metadata_keys,
+                                        const char *const *metadata_values, size_t metadata_count),
                        void *ctx, uint32_t expected_index_type) {
     if (path == NULL || expected_dimension == 0 || on_insert == NULL) {
         return -1;
@@ -659,7 +663,10 @@ int wal_replay_rich(const char *path, size_t expected_dimension,
                     return -1;
                 }
             }
-            /* Skip delete records in replay - they are handled during load */
+            if (on_delete != NULL) {
+                int cb_res = on_delete(ctx, (size_t)index_u64);
+                if (cb_res != 0) { fclose(f); return -1; }
+            }
             continue;
         }
 
@@ -765,7 +772,13 @@ int wal_replay_rich(const char *path, size_t expected_dimension,
             free(keys);
             free(values);
             free(buf);
-            /* Skip update records in replay - they modify already-inserted vectors */
+            if (on_update != NULL) {
+                int cb_res = on_update(ctx, (size_t)index_u64, buf, dim,
+                    (const char *const *)keys, (const char *const *)values, meta_count);
+                if (cb_res != 0) {
+                    free(buf); free(keys); free(values); fclose(f); return -1;
+                }
+            }
             continue;
         }
 

--- a/src/storage/wal.c
+++ b/src/storage/wal.c
@@ -170,6 +170,11 @@ int wal_append_insert(GV_WAL *wal, const float *data, size_t dimension,
         crc = crc32_update(crc, metadata_value, vlen);
     }
 
+    if (wal->version >= 2) {
+        crc = crc32_finish(crc);
+        if (write_u32(wal->file, crc) != 0) return -1;
+    }
+
     if (wal_sync(wal->file) != 0) {
         return -1;
     }
@@ -400,6 +405,11 @@ int wal_replay(const char *path, size_t expected_dimension,
             
             char **keys = NULL;
             char **values = NULL;
+            if (meta_count > 65536) {
+                free(buf);
+                fclose(f);
+                return -1;
+            }
             if (meta_count > 0) {
                 keys = (char **)malloc(sizeof(char *) * meta_count);
                 values = (char **)malloc(sizeof(char *) * meta_count);
@@ -497,6 +507,11 @@ int wal_replay(const char *path, size_t expected_dimension,
             
             char **keys = NULL;
             char **values = NULL;
+            if (meta_count > 65536) {
+                free(buf);
+                fclose(f);
+                return -1;
+            }
             if (meta_count > 0) {
                 keys = (char **)malloc(sizeof(char *) * meta_count);
                 values = (char **)malloc(sizeof(char *) * meta_count);
@@ -697,6 +712,11 @@ int wal_replay_rich(const char *path, size_t expected_dimension,
             
             char **keys = NULL;
             char **values = NULL;
+            if (meta_count > 65536) {
+                free(buf);
+                fclose(f);
+                return -1;
+            }
             if (meta_count > 0) {
                 keys = (char **)malloc(sizeof(char *) * meta_count);
                 values = (char **)malloc(sizeof(char *) * meta_count);
@@ -793,6 +813,11 @@ int wal_replay_rich(const char *path, size_t expected_dimension,
 
             char **keys = NULL;
             char **values = NULL;
+            if (meta_count > 65536) {
+                free(buf);
+                fclose(f);
+                return -1;
+            }
             if (meta_count > 0) {
                 keys = (char **)malloc(sizeof(char *) * meta_count);
                 values = (char **)malloc(sizeof(char *) * meta_count);
@@ -882,7 +907,7 @@ int wal_dump(const char *path, size_t expected_dimension, uint32_t expected_inde
 
     FILE *f = fopen(path, "rb");
     if (f == NULL) {
-        return (errno == ENOENT) ? -1 : -1;
+        return (errno == ENOENT) ? 0 : -1;
     }
 
     char magic[4] = {0};
@@ -947,6 +972,11 @@ int wal_dump(const char *path, size_t expected_dimension, uint32_t expected_inde
             
             char **keys = NULL;
             char **values = NULL;
+            if (meta_count > 65536) {
+                free(buf);
+                fclose(f);
+                return -1;
+            }
             if (meta_count > 0) {
                 keys = (char **)malloc(sizeof(char *) * meta_count);
                 values = (char **)malloc(sizeof(char *) * meta_count);

--- a/src/storage/wal.c
+++ b/src/storage/wal.c
@@ -27,25 +27,6 @@ struct GV_WAL {
     uint32_t version;
 };
 
-/* Simple CRC32 (polynomial 0xEDB88320), tableless for portability */
-static uint32_t crc32_init(void) {
-    return 0xFFFFFFFFu;
-}
-
-static uint32_t crc32_update(uint32_t crc, const void *data, size_t len) {
-    const uint8_t *p = (const uint8_t *)data;
-    for (size_t i = 0; i < len; ++i) {
-        crc ^= p[i];
-        for (int k = 0; k < 8; ++k) {
-            crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
-        }
-    }
-    return crc;
-}
-
-static uint32_t crc32_finish(uint32_t crc) {
-    return crc ^ 0xFFFFFFFFu;
-}
 
 static int wal_sync(FILE *f) {
     if (fflush(f) != 0) return -1;
@@ -146,32 +127,32 @@ int wal_append_insert(GV_WAL *wal, const float *data, size_t dimension,
         return -1;
     }
 
-    uint32_t crc = crc32_init();
+    uint32_t crc = gv_crc32_init();
 
     if (write_u8(wal->file, GV_WAL_TYPE_INSERT) != 0) return -1;
-    crc = crc32_update(crc, &(uint8_t){GV_WAL_TYPE_INSERT}, sizeof(uint8_t));
+    crc = gv_crc32_update(crc, &(uint8_t){GV_WAL_TYPE_INSERT}, sizeof(uint8_t));
     if (write_u32(wal->file, (uint32_t)dimension) != 0) return -1;
     uint32_t dim_u32 = (uint32_t)dimension;
-    crc = crc32_update(crc, &dim_u32, sizeof(uint32_t));
+    crc = gv_crc32_update(crc, &dim_u32, sizeof(uint32_t));
     if (write_floats(wal->file, data, dimension) != 0) return -1;
-    crc = crc32_update(crc, data, dimension * sizeof(float));
+    crc = gv_crc32_update(crc, data, dimension * sizeof(float));
 
     uint32_t meta_count = (metadata_key != NULL && metadata_value != NULL) ? 1u : 0u;
     if (write_u32(wal->file, meta_count) != 0) return -1;
-    crc = crc32_update(crc, &meta_count, sizeof(uint32_t));
+    crc = gv_crc32_update(crc, &meta_count, sizeof(uint32_t));
     if (meta_count == 1u) {
         if (write_string(wal->file, metadata_key) != 0) return -1;
         uint32_t klen = (uint32_t)strlen(metadata_key);
-        crc = crc32_update(crc, &klen, sizeof(uint32_t));
-        crc = crc32_update(crc, metadata_key, klen);
+        crc = gv_crc32_update(crc, &klen, sizeof(uint32_t));
+        crc = gv_crc32_update(crc, metadata_key, klen);
         if (write_string(wal->file, metadata_value) != 0) return -1;
         uint32_t vlen = (uint32_t)strlen(metadata_value);
-        crc = crc32_update(crc, &vlen, sizeof(uint32_t));
-        crc = crc32_update(crc, metadata_value, vlen);
+        crc = gv_crc32_update(crc, &vlen, sizeof(uint32_t));
+        crc = gv_crc32_update(crc, metadata_value, vlen);
     }
 
     if (wal->version >= 2) {
-        crc = crc32_finish(crc);
+        crc = gv_crc32_finish(crc);
         if (write_u32(wal->file, crc) != 0) return -1;
     }
 
@@ -194,19 +175,19 @@ int wal_append_insert_rich(GV_WAL *wal, const float *data, size_t dimension,
         return -1;
     }
 
-    uint32_t crc = crc32_init();
+    uint32_t crc = gv_crc32_init();
 
     if (write_u8(wal->file, GV_WAL_TYPE_INSERT) != 0) return -1;
-    crc = crc32_update(crc, &(uint8_t){GV_WAL_TYPE_INSERT}, sizeof(uint8_t));
+    crc = gv_crc32_update(crc, &(uint8_t){GV_WAL_TYPE_INSERT}, sizeof(uint8_t));
     if (write_u32(wal->file, (uint32_t)dimension) != 0) return -1;
     uint32_t dim_u32 = (uint32_t)dimension;
-    crc = crc32_update(crc, &dim_u32, sizeof(uint32_t));
+    crc = gv_crc32_update(crc, &dim_u32, sizeof(uint32_t));
     if (write_floats(wal->file, data, dimension) != 0) return -1;
-    crc = crc32_update(crc, data, dimension * sizeof(float));
+    crc = gv_crc32_update(crc, data, dimension * sizeof(float));
 
     uint32_t meta_count_u32 = (uint32_t)metadata_count;
     if (write_u32(wal->file, meta_count_u32) != 0) return -1;
-    crc = crc32_update(crc, &meta_count_u32, sizeof(uint32_t));
+    crc = gv_crc32_update(crc, &meta_count_u32, sizeof(uint32_t));
     
     for (size_t i = 0; i < metadata_count; i++) {
         if (metadata_keys[i] == NULL || metadata_values[i] == NULL) {
@@ -214,16 +195,16 @@ int wal_append_insert_rich(GV_WAL *wal, const float *data, size_t dimension,
         }
         if (write_string(wal->file, metadata_keys[i]) != 0) return -1;
         uint32_t klen = (uint32_t)strlen(metadata_keys[i]);
-        crc = crc32_update(crc, &klen, sizeof(uint32_t));
-        crc = crc32_update(crc, metadata_keys[i], klen);
+        crc = gv_crc32_update(crc, &klen, sizeof(uint32_t));
+        crc = gv_crc32_update(crc, metadata_keys[i], klen);
         if (write_string(wal->file, metadata_values[i]) != 0) return -1;
         uint32_t vlen = (uint32_t)strlen(metadata_values[i]);
-        crc = crc32_update(crc, &vlen, sizeof(uint32_t));
-        crc = crc32_update(crc, metadata_values[i], vlen);
+        crc = gv_crc32_update(crc, &vlen, sizeof(uint32_t));
+        crc = gv_crc32_update(crc, metadata_values[i], vlen);
     }
 
     if (wal->version >= 2) {
-        crc = crc32_finish(crc);
+        crc = gv_crc32_finish(crc);
         if (write_u32(wal->file, crc) != 0) return -1;
     }
 
@@ -238,17 +219,17 @@ int wal_append_delete(GV_WAL *wal, size_t vector_index) {
         return -1;
     }
 
-    uint32_t crc = crc32_init();
+    uint32_t crc = gv_crc32_init();
 
     if (write_u8(wal->file, GV_WAL_TYPE_DELETE) != 0) return -1;
-    crc = crc32_update(crc, &(uint8_t){GV_WAL_TYPE_DELETE}, sizeof(uint8_t));
+    crc = gv_crc32_update(crc, &(uint8_t){GV_WAL_TYPE_DELETE}, sizeof(uint8_t));
     
     uint64_t index_u64 = (uint64_t)vector_index;
     if (fwrite(&index_u64, sizeof(uint64_t), 1, wal->file) != 1) return -1;
-    crc = crc32_update(crc, &index_u64, sizeof(uint64_t));
+    crc = gv_crc32_update(crc, &index_u64, sizeof(uint64_t));
 
     if (wal->version >= 2) {
-        crc = crc32_finish(crc);
+        crc = gv_crc32_finish(crc);
         if (write_u32(wal->file, crc) != 0) return -1;
     }
 
@@ -263,24 +244,24 @@ int wal_append_update(GV_WAL *wal, size_t vector_index, const float *data, size_
         return -1;
     }
 
-    uint32_t crc = crc32_init();
+    uint32_t crc = gv_crc32_init();
 
     if (write_u8(wal->file, GV_WAL_TYPE_UPDATE) != 0) return -1;
-    crc = crc32_update(crc, &(uint8_t){GV_WAL_TYPE_UPDATE}, sizeof(uint8_t));
+    crc = gv_crc32_update(crc, &(uint8_t){GV_WAL_TYPE_UPDATE}, sizeof(uint8_t));
     
     uint64_t index_u64 = (uint64_t)vector_index;
     if (fwrite(&index_u64, sizeof(uint64_t), 1, wal->file) != 1) return -1;
-    crc = crc32_update(crc, &index_u64, sizeof(uint64_t));
+    crc = gv_crc32_update(crc, &index_u64, sizeof(uint64_t));
     
     if (write_u32(wal->file, (uint32_t)dimension) != 0) return -1;
     uint32_t dim_u32 = (uint32_t)dimension;
-    crc = crc32_update(crc, &dim_u32, sizeof(uint32_t));
+    crc = gv_crc32_update(crc, &dim_u32, sizeof(uint32_t));
     if (write_floats(wal->file, data, dimension) != 0) return -1;
-    crc = crc32_update(crc, data, dimension * sizeof(float));
+    crc = gv_crc32_update(crc, data, dimension * sizeof(float));
 
     uint32_t meta_count_u32 = (uint32_t)metadata_count;
     if (write_u32(wal->file, meta_count_u32) != 0) return -1;
-    crc = crc32_update(crc, &meta_count_u32, sizeof(uint32_t));
+    crc = gv_crc32_update(crc, &meta_count_u32, sizeof(uint32_t));
     
     for (size_t i = 0; i < metadata_count; i++) {
         if (metadata_keys[i] == NULL || metadata_values[i] == NULL) {
@@ -288,16 +269,16 @@ int wal_append_update(GV_WAL *wal, size_t vector_index, const float *data, size_
         }
         if (write_string(wal->file, metadata_keys[i]) != 0) return -1;
         uint32_t klen = (uint32_t)strlen(metadata_keys[i]);
-        crc = crc32_update(crc, &klen, sizeof(uint32_t));
-        crc = crc32_update(crc, metadata_keys[i], klen);
+        crc = gv_crc32_update(crc, &klen, sizeof(uint32_t));
+        crc = gv_crc32_update(crc, metadata_keys[i], klen);
         if (write_string(wal->file, metadata_values[i]) != 0) return -1;
         uint32_t vlen = (uint32_t)strlen(metadata_values[i]);
-        crc = crc32_update(crc, &vlen, sizeof(uint32_t));
-        crc = crc32_update(crc, metadata_values[i], vlen);
+        crc = gv_crc32_update(crc, &vlen, sizeof(uint32_t));
+        crc = gv_crc32_update(crc, metadata_values[i], vlen);
     }
 
     if (wal->version >= 2) {
-        crc = crc32_finish(crc);
+        crc = gv_crc32_finish(crc);
         if (write_u32(wal->file, crc) != 0) return -1;
     }
 
@@ -360,11 +341,11 @@ int wal_replay(const char *path, size_t expected_dimension,
                 return -1;
             }
             if (has_crc) {
-                uint32_t crc = crc32_init();
+                uint32_t crc = gv_crc32_init();
                 uint8_t type_byte = GV_WAL_TYPE_DELETE;
-                crc = crc32_update(crc, &type_byte, sizeof(uint8_t));
-                crc = crc32_update(crc, &index_u64, sizeof(uint64_t));
-                crc = crc32_finish(crc);
+                crc = gv_crc32_update(crc, &type_byte, sizeof(uint8_t));
+                crc = gv_crc32_update(crc, &index_u64, sizeof(uint64_t));
+                crc = gv_crc32_finish(crc);
                 uint32_t stored_crc = 0;
                 if (read_u32(f, &stored_crc) != 0 || stored_crc != crc) {
                     fclose(f);
@@ -438,24 +419,24 @@ int wal_replay(const char *path, size_t expected_dimension,
             }
 
             if (has_crc) {
-                uint32_t crc = crc32_init();
+                uint32_t crc = gv_crc32_init();
                 uint8_t type_byte = GV_WAL_TYPE_UPDATE;
-                crc = crc32_update(crc, &type_byte, sizeof(uint8_t));
-                crc = crc32_update(crc, &index_u64, sizeof(uint64_t));
-                crc = crc32_update(crc, &dim, sizeof(uint32_t));
-                crc = crc32_update(crc, buf, dim * sizeof(float));
-                crc = crc32_update(crc, &meta_count, sizeof(uint32_t));
+                crc = gv_crc32_update(crc, &type_byte, sizeof(uint8_t));
+                crc = gv_crc32_update(crc, &index_u64, sizeof(uint64_t));
+                crc = gv_crc32_update(crc, &dim, sizeof(uint32_t));
+                crc = gv_crc32_update(crc, buf, dim * sizeof(float));
+                crc = gv_crc32_update(crc, &meta_count, sizeof(uint32_t));
                 for (uint32_t i = 0; i < meta_count; ++i) {
                     if (keys[i] && values[i]) {
                         uint32_t klen = (uint32_t)strlen(keys[i]);
                         uint32_t vlen = (uint32_t)strlen(values[i]);
-                        crc = crc32_update(crc, &klen, sizeof(uint32_t));
-                        crc = crc32_update(crc, keys[i], klen);
-                        crc = crc32_update(crc, &vlen, sizeof(uint32_t));
-                        crc = crc32_update(crc, values[i], vlen);
+                        crc = gv_crc32_update(crc, &klen, sizeof(uint32_t));
+                        crc = gv_crc32_update(crc, keys[i], klen);
+                        crc = gv_crc32_update(crc, &vlen, sizeof(uint32_t));
+                        crc = gv_crc32_update(crc, values[i], vlen);
                     }
                 }
-                crc = crc32_finish(crc);
+                crc = gv_crc32_finish(crc);
                 uint32_t stored_crc = 0;
                 if (read_u32(f, &stored_crc) != 0 || stored_crc != crc) {
                     for (uint32_t i = 0; i < meta_count; ++i) {
@@ -540,23 +521,23 @@ int wal_replay(const char *path, size_t expected_dimension,
             }
 
             if (has_crc) {
-                uint32_t crc = crc32_init();
+                uint32_t crc = gv_crc32_init();
                 uint8_t type_byte = GV_WAL_TYPE_INSERT;
-                crc = crc32_update(crc, &type_byte, sizeof(uint8_t));
-                crc = crc32_update(crc, &dim, sizeof(uint32_t));
-                crc = crc32_update(crc, buf, dim * sizeof(float));
-                crc = crc32_update(crc, &meta_count, sizeof(uint32_t));
+                crc = gv_crc32_update(crc, &type_byte, sizeof(uint8_t));
+                crc = gv_crc32_update(crc, &dim, sizeof(uint32_t));
+                crc = gv_crc32_update(crc, buf, dim * sizeof(float));
+                crc = gv_crc32_update(crc, &meta_count, sizeof(uint32_t));
                 for (uint32_t i = 0; i < meta_count; i++) {
                     if (keys[i] && values[i]) {
                         uint32_t klen = (uint32_t)strlen(keys[i]);
                         uint32_t vlen = (uint32_t)strlen(values[i]);
-                        crc = crc32_update(crc, &klen, sizeof(uint32_t));
-                        crc = crc32_update(crc, keys[i], klen);
-                        crc = crc32_update(crc, &vlen, sizeof(uint32_t));
-                        crc = crc32_update(crc, values[i], vlen);
+                        crc = gv_crc32_update(crc, &klen, sizeof(uint32_t));
+                        crc = gv_crc32_update(crc, keys[i], klen);
+                        crc = gv_crc32_update(crc, &vlen, sizeof(uint32_t));
+                        crc = gv_crc32_update(crc, values[i], vlen);
                     }
                 }
-                crc = crc32_finish(crc);
+                crc = gv_crc32_finish(crc);
                 uint32_t stored_crc = 0;
                 if (read_u32(f, &stored_crc) != 0 || stored_crc != crc) {
                     for (uint32_t i = 0; i < meta_count; i++) {
@@ -667,11 +648,11 @@ int wal_replay_rich(const char *path, size_t expected_dimension,
                 return -1;
             }
             if (has_crc) {
-                uint32_t crc = crc32_init();
+                uint32_t crc = gv_crc32_init();
                 uint8_t type_byte = GV_WAL_TYPE_DELETE;
-                crc = crc32_update(crc, &type_byte, sizeof(uint8_t));
-                crc = crc32_update(crc, &index_u64, sizeof(uint64_t));
-                crc = crc32_finish(crc);
+                crc = gv_crc32_update(crc, &type_byte, sizeof(uint8_t));
+                crc = gv_crc32_update(crc, &index_u64, sizeof(uint64_t));
+                crc = gv_crc32_finish(crc);
                 uint32_t stored_crc = 0;
                 if (read_u32(f, &stored_crc) != 0 || stored_crc != crc) {
                     fclose(f);
@@ -745,24 +726,24 @@ int wal_replay_rich(const char *path, size_t expected_dimension,
             }
 
             if (has_crc) {
-                uint32_t crc = crc32_init();
+                uint32_t crc = gv_crc32_init();
                 uint8_t type_byte = GV_WAL_TYPE_UPDATE;
-                crc = crc32_update(crc, &type_byte, sizeof(uint8_t));
-                crc = crc32_update(crc, &index_u64, sizeof(uint64_t));
-                crc = crc32_update(crc, &dim, sizeof(uint32_t));
-                crc = crc32_update(crc, buf, dim * sizeof(float));
-                crc = crc32_update(crc, &meta_count, sizeof(uint32_t));
+                crc = gv_crc32_update(crc, &type_byte, sizeof(uint8_t));
+                crc = gv_crc32_update(crc, &index_u64, sizeof(uint64_t));
+                crc = gv_crc32_update(crc, &dim, sizeof(uint32_t));
+                crc = gv_crc32_update(crc, buf, dim * sizeof(float));
+                crc = gv_crc32_update(crc, &meta_count, sizeof(uint32_t));
                 for (uint32_t i = 0; i < meta_count; ++i) {
                     if (keys[i] && values[i]) {
                         uint32_t klen = (uint32_t)strlen(keys[i]);
                         uint32_t vlen = (uint32_t)strlen(values[i]);
-                        crc = crc32_update(crc, &klen, sizeof(uint32_t));
-                        crc = crc32_update(crc, keys[i], klen);
-                        crc = crc32_update(crc, &vlen, sizeof(uint32_t));
-                        crc = crc32_update(crc, values[i], vlen);
+                        crc = gv_crc32_update(crc, &klen, sizeof(uint32_t));
+                        crc = gv_crc32_update(crc, keys[i], klen);
+                        crc = gv_crc32_update(crc, &vlen, sizeof(uint32_t));
+                        crc = gv_crc32_update(crc, values[i], vlen);
                     }
                 }
-                crc = crc32_finish(crc);
+                crc = gv_crc32_finish(crc);
                 uint32_t stored_crc = 0;
                 if (read_u32(f, &stored_crc) != 0 || stored_crc != crc) {
                     for (uint32_t i = 0; i < meta_count; ++i) {
@@ -846,23 +827,23 @@ int wal_replay_rich(const char *path, size_t expected_dimension,
             }
 
             if (has_crc) {
-                uint32_t crc = crc32_init();
+                uint32_t crc = gv_crc32_init();
                 uint8_t type_byte = GV_WAL_TYPE_INSERT;
-                crc = crc32_update(crc, &type_byte, sizeof(uint8_t));
-                crc = crc32_update(crc, &dim, sizeof(uint32_t));
-                crc = crc32_update(crc, buf, dim * sizeof(float));
-                crc = crc32_update(crc, &meta_count, sizeof(uint32_t));
+                crc = gv_crc32_update(crc, &type_byte, sizeof(uint8_t));
+                crc = gv_crc32_update(crc, &dim, sizeof(uint32_t));
+                crc = gv_crc32_update(crc, buf, dim * sizeof(float));
+                crc = gv_crc32_update(crc, &meta_count, sizeof(uint32_t));
                 for (uint32_t i = 0; i < meta_count; i++) {
                     if (keys[i] && values[i]) {
                         uint32_t klen = (uint32_t)strlen(keys[i]);
                         uint32_t vlen = (uint32_t)strlen(values[i]);
-                        crc = crc32_update(crc, &klen, sizeof(uint32_t));
-                        crc = crc32_update(crc, keys[i], klen);
-                        crc = crc32_update(crc, &vlen, sizeof(uint32_t));
-                        crc = crc32_update(crc, values[i], vlen);
+                        crc = gv_crc32_update(crc, &klen, sizeof(uint32_t));
+                        crc = gv_crc32_update(crc, keys[i], klen);
+                        crc = gv_crc32_update(crc, &vlen, sizeof(uint32_t));
+                        crc = gv_crc32_update(crc, values[i], vlen);
                     }
                 }
-                crc = crc32_finish(crc);
+                crc = gv_crc32_finish(crc);
                 uint32_t stored_crc = 0;
                 if (read_u32(f, &stored_crc) != 0 || stored_crc != crc) {
                     for (uint32_t i = 0; i < meta_count; i++) {
@@ -1005,23 +986,23 @@ int wal_dump(const char *path, size_t expected_dimension, uint32_t expected_inde
             }
 
             if (has_crc) {
-                uint32_t crc = crc32_init();
+                uint32_t crc = gv_crc32_init();
                 uint8_t type_byte = GV_WAL_TYPE_INSERT;
-                crc = crc32_update(crc, &type_byte, sizeof(uint8_t));
-                crc = crc32_update(crc, &dim, sizeof(uint32_t));
-                crc = crc32_update(crc, buf, dim * sizeof(float));
-                crc = crc32_update(crc, &meta_count, sizeof(uint32_t));
+                crc = gv_crc32_update(crc, &type_byte, sizeof(uint8_t));
+                crc = gv_crc32_update(crc, &dim, sizeof(uint32_t));
+                crc = gv_crc32_update(crc, buf, dim * sizeof(float));
+                crc = gv_crc32_update(crc, &meta_count, sizeof(uint32_t));
                 for (uint32_t i = 0; i < meta_count; i++) {
                     if (keys[i] && values[i]) {
                         uint32_t klen = (uint32_t)strlen(keys[i]);
                         uint32_t vlen = (uint32_t)strlen(values[i]);
-                        crc = crc32_update(crc, &klen, sizeof(uint32_t));
-                        crc = crc32_update(crc, keys[i], klen);
-                        crc = crc32_update(crc, &vlen, sizeof(uint32_t));
-                        crc = crc32_update(crc, values[i], vlen);
+                        crc = gv_crc32_update(crc, &klen, sizeof(uint32_t));
+                        crc = gv_crc32_update(crc, keys[i], klen);
+                        crc = gv_crc32_update(crc, &vlen, sizeof(uint32_t));
+                        crc = gv_crc32_update(crc, values[i], vlen);
                     }
                 }
-                crc = crc32_finish(crc);
+                crc = gv_crc32_finish(crc);
                 uint32_t stored_crc = 0;
                 if (read_u32(f, &stored_crc) != 0 || stored_crc != crc) {
                     for (uint32_t i = 0; i < meta_count; i++) {

--- a/tests/corrupt_snapshot.sh
+++ b/tests/corrupt_snapshot.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 SNAP="${1:-snapshots/database.bin}"
 if [[ ! -f "$SNAP" ]]; then
-  echo "Snapshot not found: $SNAP" >&2
-  exit 1
+  echo "SKIP: Snapshot not found: $SNAP" >&2
+  exit 77
 fi
 
 tmp="$(mktemp "${SNAP}.XXXX")"

--- a/tests/corrupt_wal.sh
+++ b/tests/corrupt_wal.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 WAL="${1:-snapshots/database.bin.wal}"
 if [[ ! -f "$WAL" ]]; then
-  echo "WAL not found: $WAL" >&2
-  exit 1
+  echo "SKIP: WAL not found: $WAL" >&2
+  exit 77
 fi
 
 tmp="$(mktemp "${WAL}.XXXX")"

--- a/tests/index/test_hnsw.c
+++ b/tests/index/test_hnsw.c
@@ -4,6 +4,7 @@
 #include <math.h>
 
 #include "gigavector.h"
+#include "../test_tmp.h"
 
 #define ASSERT(cond, msg)         \
     do {                          \
@@ -68,7 +69,8 @@ static int test_hnsw_large_dataset(void) {
     if (db == NULL) {
         return 0;
     }
-    
+
+    /* Insert 100 vectors: v[i] = {i*0.08, i*0.08+0.01, ...} */
     for (int i = 0; i < 100; i++) {
         float v[8];
         for (int j = 0; j < 8; j++) {
@@ -76,12 +78,17 @@ static int test_hnsw_large_dataset(void) {
         }
         ASSERT(db_add_vector(db, v, 8) == 0, "add vector in large dataset");
     }
-    
-    float q[8] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    /* Query with the exact first vector; it must be the nearest neighbor */
+    float q[8] = {0.0f, 0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.06f, 0.07f};
     GV_SearchResult res[5];
     int n = db_search(db, q, 5, res, GV_DISTANCE_EUCLIDEAN);
     ASSERT(n == 5, "search in large dataset");
-    
+    /* Nearest neighbor must have distance 0 (exact match) */
+    if (n >= 1) {
+        ASSERT(res[0].distance < 1e-5f, "nearest neighbor is correct");
+    }
+
     db_close(db);
     return 0;
 }
@@ -135,27 +142,32 @@ static int test_hnsw_range_search(void) {
 }
 
 static int test_hnsw_persistence(void) {
-    const char *path = "tmp_hnsw_db.bin";
+    char path[256];
+    if (gv_test_make_temp_path(path, sizeof(path), "gv_hnsw_persist", ".bin") != 0) return 0;
     remove(path);
-    
+
     GV_Database *db = db_open(path, 3, GV_INDEX_TYPE_HNSW);
     if (db == NULL) {
         return 0;
     }
-    
+
     float v[3] = {1.0f, 2.0f, 3.0f};
     ASSERT(db_add_vector(db, v, 3) == 0, "add vector");
     ASSERT(db_save(db, NULL) == 0, "save database");
     db_close(db);
-    
+
     GV_Database *db2 = db_open(path, 3, GV_INDEX_TYPE_HNSW);
     ASSERT(db2 != NULL, "reopen database");
-    
+
     float q[3] = {1.0f, 2.0f, 3.0f};
     GV_SearchResult res[1];
     int n = db_search(db2, q, 1, res, GV_DISTANCE_EUCLIDEAN);
     ASSERT(n == 1, "search after reload");
-    
+    /* The only inserted vector should be the nearest neighbor */
+    if (n == 1 && res[0].vector != NULL) {
+        ASSERT(res[0].distance < 1e-5f, "nearest neighbor is exact match after reload");
+    }
+
     db_close(db2);
     remove(path);
     return 0;

--- a/tests/index/test_hnsw_concurrent.c
+++ b/tests/index/test_hnsw_concurrent.c
@@ -1,0 +1,98 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#include "gigavector.h"
+
+#define ASSERT(cond, msg)         \
+    do {                          \
+        if (!(cond)) {            \
+            fprintf(stderr, "FAIL: %s\n", msg); \
+            return -1;            \
+        }                         \
+    } while (0)
+
+#define N_INSERT_THREADS 4
+#define N_SEARCH_THREADS 4
+#define INSERTS_PER_THREAD 64
+#define SEARCHES_PER_THREAD 32
+
+typedef struct {
+    GV_Database *db;
+    int thread_id;
+    int result;
+} ThreadArg;
+
+static void *insert_worker(void *arg) {
+    ThreadArg *a = (ThreadArg *)arg;
+    for (int i = 0; i < INSERTS_PER_THREAD; i++) {
+        float v[4];
+        for (int j = 0; j < 4; j++)
+            v[j] = (float)(a->thread_id * INSERTS_PER_THREAD + i + j) * 0.01f;
+        if (db_add_vector(a->db, v, 4) != 0) {
+            a->result = -1;
+            return NULL;
+        }
+    }
+    a->result = 0;
+    return NULL;
+}
+
+static void *search_worker(void *arg) {
+    ThreadArg *a = (ThreadArg *)arg;
+    for (int i = 0; i < SEARCHES_PER_THREAD; i++) {
+        float q[4] = {(float)i * 0.01f, 0.0f, 0.0f, 0.0f};
+        GV_SearchResult res[3];
+        int n = db_search(a->db, q, 3, res, GV_DISTANCE_EUCLIDEAN);
+        (void)n;
+        gv_search_results_free(res, (size_t)(n > 0 ? n : 0));
+    }
+    a->result = 0;
+    return NULL;
+}
+
+static int test_concurrent_insert_search(void) {
+    GV_Database *db = db_open(NULL, 4, GV_INDEX_TYPE_HNSW);
+    if (db == NULL) return 0;
+
+    /* Seed with some initial data so searches have something to find */
+    for (int i = 0; i < 32; i++) {
+        float v[4] = {(float)i * 0.01f, (float)i * 0.02f,
+                      (float)i * 0.03f, (float)i * 0.04f};
+        db_add_vector(db, v, 4);
+    }
+
+    pthread_t insert_threads[N_INSERT_THREADS];
+    pthread_t search_threads[N_SEARCH_THREADS];
+    ThreadArg insert_args[N_INSERT_THREADS];
+    ThreadArg search_args[N_SEARCH_THREADS];
+
+    for (int i = 0; i < N_INSERT_THREADS; i++) {
+        insert_args[i].db = db;
+        insert_args[i].thread_id = i;
+        insert_args[i].result = 0;
+        pthread_create(&insert_threads[i], NULL, insert_worker, &insert_args[i]);
+    }
+    for (int i = 0; i < N_SEARCH_THREADS; i++) {
+        search_args[i].db = db;
+        search_args[i].thread_id = i;
+        search_args[i].result = 0;
+        pthread_create(&search_threads[i], NULL, search_worker, &search_args[i]);
+    }
+
+    for (int i = 0; i < N_INSERT_THREADS; i++)
+        pthread_join(insert_threads[i], NULL);
+    for (int i = 0; i < N_SEARCH_THREADS; i++)
+        pthread_join(search_threads[i], NULL);
+
+    for (int i = 0; i < N_INSERT_THREADS; i++)
+        ASSERT(insert_args[i].result == 0, "insert thread succeeded");
+
+    db_close(db);
+    return 0;
+}
+
+int main(void) {
+    return test_concurrent_insert_search();
+}

--- a/tests/storage/test_wal.c
+++ b/tests/storage/test_wal.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "gigavector.h"
+#include "../test_tmp.h"
 
 #define ASSERT(cond, msg)         \
     do {                          \
@@ -45,228 +46,226 @@ static int on_insert_rich_cb(void *ctx, const float *data, size_t dimension,
 }
 
 static int test_wal_open_close(void) {
-    const char *wal_path = "tmp_test_wal.bin.wal";
+    char wal_path[256];
+    if (gv_test_make_temp_path(wal_path, sizeof(wal_path), "gv_wal_open", ".wal") != 0) return 0;
     remove(wal_path);
-    
+
     GV_WAL *wal = wal_open(wal_path, 3, GV_INDEX_TYPE_KDTREE);
     ASSERT(wal != NULL, "wal open");
-    
+
     wal_close(wal);
-    
     remove(wal_path);
     return 0;
 }
 
 static int test_wal_append_insert(void) {
-    const char *wal_path = "tmp_test_wal_insert.bin.wal";
+    char wal_path[256];
+    if (gv_test_make_temp_path(wal_path, sizeof(wal_path), "gv_wal_insert", ".wal") != 0) return 0;
     remove(wal_path);
-    
+
     GV_WAL *wal = wal_open(wal_path, 2, GV_INDEX_TYPE_KDTREE);
     ASSERT(wal != NULL, "wal open");
-    
+
     float v[2] = {1.0f, 2.0f};
     ASSERT(wal_append_insert(wal, v, 2, "tag", "test") == 0, "append insert");
-    
     ASSERT(wal_append_insert(wal, v, 2, NULL, NULL) == 0, "append insert without metadata");
-    
+
     wal_close(wal);
-    
     remove(wal_path);
     return 0;
 }
 
 static int test_wal_append_insert_rich(void) {
-    const char *wal_path = "tmp_test_wal_rich.bin.wal";
+    char wal_path[256];
+    if (gv_test_make_temp_path(wal_path, sizeof(wal_path), "gv_wal_rich", ".wal") != 0) return 0;
     remove(wal_path);
-    
+
     GV_WAL *wal = wal_open(wal_path, 2, GV_INDEX_TYPE_KDTREE);
     ASSERT(wal != NULL, "wal open");
-    
+
     float v[2] = {1.0f, 2.0f};
     const char *keys[] = {"tag", "owner", "source"};
     const char *values[] = {"a", "b", "demo"};
-    
+
     ASSERT(wal_append_insert_rich(wal, v, 2, keys, values, 3) == 0, "append insert rich");
-    
+
     wal_close(wal);
-    
     remove(wal_path);
     return 0;
 }
 
 static int test_wal_append_delete(void) {
-    const char *wal_path = "tmp_test_wal_delete.bin.wal";
+    char wal_path[256];
+    if (gv_test_make_temp_path(wal_path, sizeof(wal_path), "gv_wal_delete", ".wal") != 0) return 0;
     remove(wal_path);
-    
+
     GV_WAL *wal = wal_open(wal_path, 2, GV_INDEX_TYPE_KDTREE);
     ASSERT(wal != NULL, "wal open");
-    
+
     ASSERT(wal_append_delete(wal, 0) == 0, "append delete");
-    
+
     wal_close(wal);
-    
     remove(wal_path);
     return 0;
 }
 
 static int test_wal_append_update(void) {
-    const char *wal_path = "tmp_test_wal_update.bin.wal";
+    char wal_path[256];
+    if (gv_test_make_temp_path(wal_path, sizeof(wal_path), "gv_wal_update", ".wal") != 0) return 0;
     remove(wal_path);
-    
+
     GV_WAL *wal = wal_open(wal_path, 2, GV_INDEX_TYPE_KDTREE);
     ASSERT(wal != NULL, "wal open");
-    
+
     float v[2] = {10.0f, 20.0f};
     const char *keys[] = {"tag"};
     const char *values[] = {"updated"};
-    
+
     ASSERT(wal_append_update(wal, 0, v, 2, keys, values, 1) == 0, "append update");
-    
+
     wal_close(wal);
-    
     remove(wal_path);
     return 0;
 }
 
 static int test_wal_truncate(void) {
-    const char *wal_path = "tmp_test_wal_truncate.bin.wal";
+    char wal_path[256];
+    if (gv_test_make_temp_path(wal_path, sizeof(wal_path), "gv_wal_trunc", ".wal") != 0) return 0;
     remove(wal_path);
-    
+
     GV_WAL *wal = wal_open(wal_path, 2, GV_INDEX_TYPE_KDTREE);
     ASSERT(wal != NULL, "wal open");
-    
+
     float v[2] = {1.0f, 2.0f};
     ASSERT(wal_append_insert(wal, v, 2, NULL, NULL) == 0, "append insert");
-    
     ASSERT(wal_truncate(wal) == 0, "truncate wal");
-    
+
     wal_close(wal);
-    
     remove(wal_path);
     return 0;
 }
 
 static int test_wal_reset(void) {
-    const char *wal_path = "tmp_test_wal_reset.bin.wal";
+    char wal_path[256];
+    if (gv_test_make_temp_path(wal_path, sizeof(wal_path), "gv_wal_reset", ".wal") != 0) return 0;
     remove(wal_path);
-    
+
     GV_WAL *wal = wal_open(wal_path, 2, GV_INDEX_TYPE_KDTREE);
     ASSERT(wal != NULL, "wal open");
-    
+
     float v[2] = {1.0f, 2.0f};
     ASSERT(wal_append_insert(wal, v, 2, NULL, NULL) == 0, "append insert");
-    
+
     wal_close(wal);
-    
+
     ASSERT(wal_reset(wal_path) == 0, "reset wal");
-    
+
     remove(wal_path);
     return 0;
 }
 
 static int test_wal_dump(void) {
-    const char *wal_path = "tmp_test_wal_dump.bin.wal";
+    char wal_path[256];
+    if (gv_test_make_temp_path(wal_path, sizeof(wal_path), "gv_wal_dump", ".wal") != 0) return 0;
     remove(wal_path);
-    
+
     GV_WAL *wal = wal_open(wal_path, 2, GV_INDEX_TYPE_KDTREE);
     ASSERT(wal != NULL, "wal open");
-    
+
     float v[2] = {1.0f, 2.0f};
     ASSERT(wal_append_insert(wal, v, 2, "tag", "test") == 0, "append insert");
-    
+
     wal_close(wal);
-    
+
     FILE *out = fopen("/dev/null", "w");
     if (out != NULL) {
         int dump_result = wal_dump(wal_path, 2, GV_INDEX_TYPE_KDTREE, out);
         fclose(out);
-        if (dump_result != 0) {
-            remove(wal_path);
-            return 0;
-        }
+        ASSERT(dump_result == 0, "wal dump succeeded");
     }
-    
+
     remove(wal_path);
     return 0;
 }
 
 static int test_wal_replay(void) {
-    const char *wal_path = "tmp_test_wal_replay.bin.wal";
+    char wal_path[256];
+    if (gv_test_make_temp_path(wal_path, sizeof(wal_path), "gv_wal_replay", ".wal") != 0) return 0;
     remove(wal_path);
-    
+
     GV_WAL *wal = wal_open(wal_path, 2, GV_INDEX_TYPE_KDTREE);
     ASSERT(wal != NULL, "wal open");
-    
+
     float v[2] = {1.0f, 2.0f};
     ASSERT(wal_append_insert(wal, v, 2, "tag", "test") == 0, "append insert");
-    
+
     wal_close(wal);
-    
+
     int replay_count = 0;
     ReplayCtx ctx = { .count = &replay_count };
 
     int replay_result = wal_replay(wal_path, 2, on_insert_basic_cb, &ctx, GV_INDEX_TYPE_KDTREE);
-    if (replay_result != 0) {
-        remove(wal_path);
-        return 0;
-    }
-    ASSERT(replay_count >= 0, "replay count");
-    
+    ASSERT(replay_result == 0, "wal replay succeeded");
+    ASSERT(replay_count == 1, "replay count is 1");
+
     remove(wal_path);
     return 0;
 }
 
 static int test_wal_replay_rich(void) {
-    const char *wal_path = "tmp_test_wal_replay_rich.bin.wal";
+    char wal_path[256];
+    if (gv_test_make_temp_path(wal_path, sizeof(wal_path), "gv_wal_replay_rich", ".wal") != 0) return 0;
     remove(wal_path);
-    
+
     GV_WAL *wal = wal_open(wal_path, 2, GV_INDEX_TYPE_KDTREE);
     ASSERT(wal != NULL, "wal open");
-    
+
     float v[2] = {1.0f, 2.0f};
     const char *keys[] = {"tag", "owner"};
     const char *values[] = {"a", "b"};
     ASSERT(wal_append_insert_rich(wal, v, 2, keys, values, 2) == 0, "append insert rich");
-    
+
     wal_close(wal);
-    
+
     int replay_count = 0;
     ReplayCtx ctx = { .count = &replay_count };
 
-    ASSERT(wal_replay_rich(wal_path, 2, on_insert_rich_cb, &ctx, GV_INDEX_TYPE_KDTREE) == 0, "wal replay rich");
-    ASSERT(replay_count == 1, "replay count");
-    
+    ASSERT(wal_replay_rich(wal_path, 2, on_insert_rich_cb, NULL, NULL, &ctx, GV_INDEX_TYPE_KDTREE) == 0,
+           "wal replay rich succeeded");
+    ASSERT(replay_count == 1, "replay count is 1");
+
     remove(wal_path);
     return 0;
 }
 
 static int test_wal_in_database(void) {
-    const char *path = "tmp_wal_db.bin";
-    const char *wal_path = "tmp_wal_db.bin.wal";
-    remove(path);
+    char db_path[256], wal_path[256];
+    if (gv_test_make_temp_path(db_path, sizeof(db_path), "gv_wal_db", ".bin") != 0) return 0;
+    if (gv_test_make_temp_path(wal_path, sizeof(wal_path), "gv_wal_db", ".wal") != 0) return 0;
+    remove(db_path);
     remove(wal_path);
-    
-    GV_Database *db = db_open(path, 2, GV_INDEX_TYPE_KDTREE);
+
+    GV_Database *db = db_open(db_path, 2, GV_INDEX_TYPE_KDTREE);
     ASSERT(db != NULL, "db open");
-    
+
     ASSERT(db_set_wal(db, wal_path) == 0, "set wal");
-    
+
     float v[2] = {1.0f, 2.0f};
     ASSERT(db_add_vector_with_metadata(db, v, 2, "tag", "test") == 0, "add vector");
-    
+
     int dump_result = db_wal_dump(db, stdout);
     if (dump_result != 0) {
         db_disable_wal(db);
         db_close(db);
-        remove(path);
+        remove(db_path);
         remove(wal_path);
         return 0;
     }
-    
+
     db_disable_wal(db);
     db_close(db);
-    
-    remove(path);
+
+    remove(db_path);
     remove(wal_path);
     return 0;
 }
@@ -286,4 +285,3 @@ int main(void) {
     rc |= test_wal_in_database();
     return rc;
 }
-


### PR DESCRIPTION
## Summary
- Fix NULL deref, WAL CRC, PKCS7 padding, JWT randomness, and search result leaks
- Replace global CMake sanitizer flags with per-target INTERFACE library
- Add concurrent HNSW test, nearest-neighbor correctness assertions, and CTest shell test registration

## Test plan
- [ ] `cmake -DBUILD_TESTS=ON .. && ctest` passes all C tests
- [ ] `ctest -R corrupt_wal` shows SKIP (no WAL file present)
- [ ] Python: `mypy gigavector` resolves types via `py.typed`