### PR TITLE
fix: security hardening and data-correctness bugs

### DIFF
--- a/python/src/gigavector/dashboard/backend/server.py
+++ b/python/src/gigavector/dashboard/backend/server.py
@@ -530,7 +530,13 @@ class _Handler(BaseHTTPRequestHandler):
             return self._send_error_json(400, "invalid_request", "Missing 'path'")
         try:
             new_db = backup_restore_to_db(body["path"])
+            old_db = self.server.db
             self.server.db = new_db
+            if old_db is not None:
+                try:
+                    old_db.close()
+                except Exception:
+                    pass
             self._send_json({"success": True, "vector_count": new_db.count, "dimension": new_db.dimension})
         except Exception as e:
             self._send_error_json(500, "restore_failed", str(e))

--- a/src/api/rest_handlers.c
+++ b/src/api/rest_handlers.c
@@ -352,9 +352,28 @@ GV_HttpResponse *rest_handle_vectors_post(const GV_HandlerContext *ctx,
             size_t meta_count = json_object_length(metadata);
             if (meta_count > 0) {
                 GV_JsonEntry *entries = metadata->data.object.entries;
-                result = db_add_vector_with_metadata(ctx->db, vec, dim,
-                                                         entries[0].key,
-                                                         json_get_string(entries[0].value));
+                const char **mkeys = malloc(meta_count * sizeof(char *));
+                const char **mvals = malloc(meta_count * sizeof(char *));
+                char **mval_bufs = malloc(meta_count * sizeof(char *));
+                if (mkeys && mvals && mval_bufs) {
+                    for (size_t mi = 0; mi < meta_count; mi++) {
+                        mkeys[mi] = entries[mi].key;
+                        if (json_is_string(entries[mi].value)) {
+                            mvals[mi] = json_get_string(entries[mi].value);
+                            mval_bufs[mi] = NULL;
+                        } else {
+                            mval_bufs[mi] = json_stringify(entries[mi].value, false);
+                            mvals[mi] = mval_bufs[mi];
+                        }
+                    }
+                    result = db_add_vector_with_rich_metadata(ctx->db, vec, dim, mkeys, mvals, meta_count);
+                    for (size_t mi = 0; mi < meta_count; mi++) free(mval_bufs[mi]);
+                } else {
+                    result = db_add_vector(ctx->db, vec, dim);
+                }
+                free(mkeys);
+                free(mvals);
+                free(mval_bufs);
             } else {
                 result = db_add_vector(ctx->db, vec, dim);
             }
@@ -613,7 +632,14 @@ GV_HttpResponse *rest_handle_search(const GV_HandlerContext *ctx,
             for (size_t fi = 0; fi < nfilter && pos < sizeof(expr) - 1; fi++) {
                 const char *val = json_get_string(entries[fi].value);
                 if (!val) continue;
-                /* Escape backslashes and quotes in val before interpolation */
+                /* Escape backslashes and quotes in key and val before interpolation */
+                char safe_key[256];
+                size_t sk = 0;
+                for (size_t ki = 0; entries[fi].key[ki] && sk + 2 < sizeof(safe_key); ki++) {
+                    if (entries[fi].key[ki] == '"' || entries[fi].key[ki] == '\\') safe_key[sk++] = '\\';
+                    safe_key[sk++] = entries[fi].key[ki];
+                }
+                safe_key[sk] = '\0';
                 char safe_val[256];
                 size_t sv = 0;
                 for (size_t vi = 0; val[vi] && sv + 2 < sizeof(safe_val); vi++) {
@@ -624,7 +650,7 @@ GV_HttpResponse *rest_handle_search(const GV_HandlerContext *ctx,
                 int n = snprintf(expr + pos, sizeof(expr) - pos,
                                  "%s%s == \"%s\"",
                                  fi > 0 ? " AND " : "",
-                                 entries[fi].key, safe_val);
+                                 safe_key, safe_val);
                 if (n > 0) {
                     size_t written = (size_t)n;
                     pos += written < sizeof(expr) - pos ? written : sizeof(expr) - pos - 1;

--- a/src/api/server.c
+++ b/src/api/server.c
@@ -238,6 +238,9 @@ static int check_auth(const GV_Server *server, struct MHD_Connection *connection
         }
     }
 
+    if (!auth) {
+        return 0;
+    }
     size_t key_len = strlen(server->config.api_key);
     size_t auth_len = strlen(auth);
     if (auth_len != key_len ||

--- a/src/api/server.c
+++ b/src/api/server.c
@@ -7,6 +7,7 @@
 
 #include "api/server.h"
 #include "api/rest_handlers.h"
+#include "security/crypto.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -237,7 +238,12 @@ static int check_auth(const GV_Server *server, struct MHD_Connection *connection
         }
     }
 
-    if (!auth || strcmp(auth, server->config.api_key) != 0) {
+    size_t key_len = strlen(server->config.api_key);
+    size_t auth_len = strlen(auth);
+    if (auth_len != key_len ||
+        crypto_constant_time_compare((const unsigned char *)auth,
+                                     (const unsigned char *)server->config.api_key,
+                                     key_len) != 0) {
         return 0;
     }
     return 1;

--- a/src/security/auth.c
+++ b/src/security/auth.c
@@ -530,9 +530,21 @@ GV_AuthResult auth_verify_jwt(GV_AuthManager *auth, const char *token,
     size_t secret_len = auth->config.jwt.secret_len;
     if (secret_len == 0) secret_len = strlen(auth->config.jwt.secret);
 
-    for (size_t i = 0; i < secret_len && i < 64; i++) {
-        key_ipad[i] ^= ((unsigned char *)auth->config.jwt.secret)[i];
-        key_opad[i] ^= ((unsigned char *)auth->config.jwt.secret)[i];
+    /* RFC 2104: keys longer than block size must be hashed first */
+    unsigned char hashed_key[32];
+    const unsigned char *key_bytes = (const unsigned char *)auth->config.jwt.secret;
+    size_t key_xor_len = secret_len;
+    if (secret_len > 64) {
+        SHA256_CTX kctx;
+        sha256_init(&kctx);
+        sha256_update(&kctx, key_bytes, secret_len);
+        sha256_final(&kctx, hashed_key);
+        key_bytes = hashed_key;
+        key_xor_len = 32;
+    }
+    for (size_t i = 0; i < key_xor_len; i++) {
+        key_ipad[i] ^= key_bytes[i];
+        key_opad[i] ^= key_bytes[i];
     }
 
     unsigned char inner_hash[32];
@@ -702,14 +714,30 @@ int auth_generate_jwt(GV_AuthManager *auth, const char *subject,
     char header_b64[128];
     base64url_encode(header, strlen(header), header_b64);
 
-    /* Build payload */
+    /* Build payload — escape subject to prevent JSON injection */
     uint64_t now = (uint64_t)time(NULL);
     uint64_t exp = now + expires_in;
+
+    char safe_subject[512];
+    {
+        size_t si = 0;
+        for (size_t i = 0; subject[i] && si + 2 < sizeof(safe_subject); i++) {
+            unsigned char ch = (unsigned char)subject[i];
+            if (ch == '"' || ch == '\\') {
+                safe_subject[si++] = '\\';
+            } else if (ch < 0x20) {
+                /* Drop control characters */
+                continue;
+            }
+            safe_subject[si++] = (char)ch;
+        }
+        safe_subject[si] = '\0';
+    }
 
     char payload[512];
     snprintf(payload, sizeof(payload),
              "{\"sub\":\"%s\",\"iat\":%llu,\"exp\":%llu}",
-             subject, (unsigned long long)now, (unsigned long long)exp);
+             safe_subject, (unsigned long long)now, (unsigned long long)exp);
 
     char payload_b64[512];
     base64url_encode(payload, strlen(payload), payload_b64);
@@ -718,14 +746,27 @@ int auth_generate_jwt(GV_AuthManager *auth, const char *subject,
     char sig_input[1024];
     snprintf(sig_input, sizeof(sig_input), "%s.%s", header_b64, payload_b64);
 
-    /* HMAC-SHA256 - simplified (XOR secret with inner/outer pad) */
+    /* HMAC-SHA256 */
     unsigned char key_ipad[64], key_opad[64];
     memset(key_ipad, 0x36, 64);
     memset(key_opad, 0x5c, 64);
 
-    for (size_t i = 0; i < auth->config.jwt.secret_len && i < 64; i++) {
-        key_ipad[i] ^= ((unsigned char *)auth->config.jwt.secret)[i];
-        key_opad[i] ^= ((unsigned char *)auth->config.jwt.secret)[i];
+    /* RFC 2104: keys longer than block size must be hashed first */
+    unsigned char hashed_sign_key[32];
+    const unsigned char *sign_key_bytes = (const unsigned char *)auth->config.jwt.secret;
+    size_t sign_key_len = auth->config.jwt.secret_len;
+    if (sign_key_len == 0) sign_key_len = strlen(auth->config.jwt.secret);
+    if (sign_key_len > 64) {
+        SHA256_CTX kctx;
+        sha256_init(&kctx);
+        sha256_update(&kctx, sign_key_bytes, sign_key_len);
+        sha256_final(&kctx, hashed_sign_key);
+        sign_key_bytes = hashed_sign_key;
+        sign_key_len = 32;
+    }
+    for (size_t i = 0; i < sign_key_len; i++) {
+        key_ipad[i] ^= sign_key_bytes[i];
+        key_opad[i] ^= sign_key_bytes[i];
     }
 
     unsigned char inner_hash[32];

--- a/src/security/crypto.c
+++ b/src/security/crypto.c
@@ -449,13 +449,17 @@ int crypto_decrypt(GV_CryptoContext *ctx, const GV_CryptoKey *key,
         memcpy(prev_block, ciphertext + pos, 16);
     }
 
-    /* Remove PKCS7 padding */
+    /* Remove and validate PKCS7 padding */
     unsigned char pad = plaintext[ciphertext_len - 1];
-    if (pad > 0 && pad <= 16) {
-        *plaintext_len = ciphertext_len - pad;
-    } else {
-        *plaintext_len = ciphertext_len;
+    if (pad == 0 || pad > 16) {
+        return -1;
     }
+    for (unsigned char pi = 1; pi < pad; pi++) {
+        if (plaintext[ciphertext_len - 1 - pi] != pad) {
+            return -1;
+        }
+    }
+    *plaintext_len = ciphertext_len - pad;
 
     return 0;
 }
@@ -562,11 +566,16 @@ int crypto_decrypt_file(GV_CryptoContext *ctx, const GV_CryptoKey *key,
             fclose(fout);
             return -1;
         }
+        /* Capture last ciphertext block before overwriting buffer */
+        unsigned char last_cipher_block[16];
+        if (nread >= 16) {
+            memcpy(last_cipher_block, buffer + nread - 16, 16);
+        }
         fwrite(plain, 1, plain_len, fout);
 
-        /* Update IV for next block */
+        /* Update IV using the last ciphertext block (CBC chaining) */
         if (nread >= 16) {
-            memcpy(working_key.iv, buffer + nread - 16, 16);
+            memcpy(working_key.iv, last_cipher_block, 16);
         }
     }
 

--- a/src/storage/backup.c
+++ b/src/storage/backup.c
@@ -115,6 +115,10 @@ GV_BackupResult *backup_create(GV_Database *db, const char *backup_path,
 
     /* Placeholder for sizes and checksum (will update at end) */
     long sizes_pos = ftell(fp);
+    if (sizes_pos < 0) {
+        fclose(fp);
+        return create_result(0, "Failed to get file position");
+    }
     uint64_t zero = 0;
     if (fwrite(&zero, sizeof(zero), 1, fp) != 1 ||
         fwrite(&zero, sizeof(zero), 1, fp) != 1) {
@@ -134,12 +138,23 @@ GV_BackupResult *backup_create(GV_Database *db, const char *backup_path,
         const float *vector = database_get_vector(db, i);
 
         if (vector) {
-            fwrite(vector, 1, vector_size, fp);
+            if (fwrite(vector, 1, vector_size, fp) != vector_size) {
+                fclose(fp);
+                return create_result(0, "Failed to write vector data (disk full?)");
+            }
             data_size += vector_size;
         } else {
             float *zeros = calloc(dimension, sizeof(float));
-            fwrite(zeros, 1, vector_size, fp);
+            if (!zeros) {
+                fclose(fp);
+                return create_result(0, "Failed to allocate zero-vector buffer");
+            }
+            size_t zw = fwrite(zeros, 1, vector_size, fp);
             free(zeros);
+            if (zw != vector_size) {
+                fclose(fp);
+                return create_result(0, "Failed to write placeholder vector (disk full?)");
+            }
             data_size += vector_size;
         }
 
@@ -153,6 +168,10 @@ GV_BackupResult *backup_create(GV_Database *db, const char *backup_path,
     }
 
     long end_pos = ftell(fp);
+    if (end_pos < 0) {
+        fclose(fp);
+        return create_result(0, "Failed to get file position after writing vectors");
+    }
     fseek(fp, sizes_pos, SEEK_SET);
     fwrite(&data_size, sizeof(data_size), 1, fp);
     fwrite(&zero, sizeof(zero), 1, fp);
@@ -520,10 +539,12 @@ GV_BackupResult *backup_verify(const char *backup_path, const char *decryption_k
         return create_result(0, "Backup file appears truncated");
     }
 
-    /* Verify checksum if present */
+    /* Verify checksum if present — force null termination before compare */
+    header.checksum[BACKUP_CHECKSUM_LEN - 1] = '\0';
     if (header.checksum[0] != '\0') {
         char computed[65];
         if (backup_compute_checksum(backup_path, computed) == 0) {
+            computed[64] = '\0';
             if (strcmp(computed, header.checksum) != 0) {
                 return create_result(0, "Checksum mismatch — backup may be corrupted");
             }

--- a/src/storage/database.c
+++ b/src/storage/database.c
@@ -1338,7 +1338,6 @@ GV_Database *db_open_with_ivfpq_config(const char *filepath, size_t dimension,
     db->root = NULL;
     db->hnsw_index = NULL;
     db->sparse_index = NULL;
-    db->sparse_index = NULL;
     db->filepath = NULL;
     db->wal_path = NULL;
 


### PR DESCRIPTION
## Summary

- **S1** Timing-safe API key comparison — replaced `strcmp` with `crypto_constant_time_compare`
- **S4** HMAC RFC 2104 compliance — hash keys >64 bytes before XOR (both sign and verify paths)
- **S5** PKCS7 padding — validate all padding bytes, not just the last one
- **S6** Decrypt file IV-chaining bug — was reading from plaintext buffer instead of ciphertext
- **S8** JWT subject injection — JSON-escape subject string before interpolating into payload
- **S12** Filter expression injection — escape metadata *keys* (not just values) before building expr
- **B1** `database.c` — remove duplicate `sparse_index = NULL` assignment
- **B3** Single-vector REST add — use `db_add_vector_with_rich_metadata` so all metadata keys are stored (was silently dropping all but the first)
- **B8** Dashboard backup restore — close old DB handle before swapping to prevent FD leak
- **B9** Backup checksum — force null-terminate `header.checksum` buffer before `strcmp`
- **B10/B11** Backup `fwrite`/`ftell` — check return values and fail fast on disk-full or seek error

## Test plan

- [ ] Build passes with existing `make` / `cmake` pipeline
- [ ] Run `python/tests/test_api.py` — existing tests pass
- [ ] Run `test_gigavector.py` — backup/restore tests pass
- [ ] Manually verify API-key auth still works after timing-safe change
- [ ] Verify JWT issue/verify round-trip with secrets of various lengths (< 64, exactly 64, > 64 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)