### PR TITLE
chore: add ruff and clang-format via pre-commit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+BreakBeforeBraces: Attach
+AlwaysBreakAfterReturnType: None
+PointerAlignment: Right
+SpaceBeforeParens: ControlStatements
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+SortIncludes: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v19.1.7
+    hooks:
+      - id: clang-format
+        types_or: [c, c++]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,6 +36,22 @@ packages = [
 
 include-package-data = true
 
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "C4", "N"]
+ignore = ["E501", "N802", "N803", "N806", "B904"]
+
+[tool.ruff.lint.per-file-ignores]
+"src/gigavector/_ffi.py" = ["E", "W", "F"]
+"src/gigavector/_core.py" = ["N"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
 [tool.setuptools.package-data]
 gigavector = [
 	"py.typed",

--- a/python/src/gigavector/async_api.py
+++ b/python/src/gigavector/async_api.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Iterable, Sequence
+from typing import Any
 
 from ._core import Database, DistanceType, IndexType, ScrollEntry, SearchHit
 

--- a/python/src/gigavector/benchmark.py
+++ b/python/src/gigavector/benchmark.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from typing import Iterable, Sequence
 
 from ._core import Database, DistanceType
 

--- a/python/src/gigavector/pool.py
+++ b/python/src/gigavector/pool.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
 
 from ._core import Database, IndexType
 


### PR DESCRIPTION
Adds two linting/formatting tools wired through pre-commit:

- **ruff** — Python linter and formatter (replaces flake8 + black + isort). Config lives in `python/pyproject.toml`. `_ffi.py` and `_core.py` have targeted ignores to avoid noise from generated/large files.
- **clang-format** — C/C++ formatter. Style config in `.clang-format` (LLVM base, 4-space indent, 100-col limit).

## Usage
```bash
pip install pre-commit
pre-commit install        # installs git hooks
pre-commit run --all-files  # run manually
```